### PR TITLE
Create tag component

### DIFF
--- a/packages/system/src/components/tag.css.ts
+++ b/packages/system/src/components/tag.css.ts
@@ -1,0 +1,21 @@
+import { style } from "@vanilla-extract/css"
+import { sprinkles } from "../sprinkles/sprinkles.css"
+
+export const tagStyle = style([
+	sprinkles({
+		paddingY: "small",
+	}),
+	{
+		background: "rgba(0, 0, 0, 0.04)",
+		borderRadius: "4px",
+		color: "#4D545C",
+		cursor: "pointer",
+		fontSize: "10px",
+		fontWeight: 600,
+		lineHeight: 1,
+		letterSpacing: "0.05em",
+		paddingLeft: "6px",
+		paddingRight: "6px",
+		textTransform: "uppercase",
+	},
+])

--- a/packages/system/src/components/tag.stories.tsx
+++ b/packages/system/src/components/tag.stories.tsx
@@ -1,0 +1,16 @@
+import { Story, Meta } from "@storybook/react"
+import { Tag, TagProps } from "./tag"
+
+export default {
+	title: "Tag",
+	component: Tag,
+} as Meta
+
+const Template: Story<TagProps> = (args) => <Tag {...args} />
+
+export const Example = Template.bind({})
+
+Example.args = {
+	href: "/data-visualization",
+	children: "Data Visualization",
+}

--- a/packages/system/src/components/tag.tsx
+++ b/packages/system/src/components/tag.tsx
@@ -1,0 +1,14 @@
+import classNames from "classnames"
+import React from "react"
+import { tagStyle } from "./tag.css"
+
+export interface TagProps
+	extends React.AnchorHTMLAttributes<HTMLAnchorElement> {}
+
+export function Tag({ children, className, href, ...props }: TagProps) {
+	return (
+		<a href={href} className={classNames(className, tagStyle)} {...props}>
+			{children}
+		</a>
+	)
+}


### PR DESCRIPTION
"Building a tag should be easy!" I thought. "Simple little component, nothing to it!"

But basically all of the styles I applied to match the mockups weren't in the sprinkles setup. Not ideal.

I'm not sure how well organized the Figma project is for us to extract common things like color palettes or reused spacings. It doesn't look like it's that well organized. Either we go through it manually looking for these things to get as many of them into the sprinkles file as we can, or we ask the designers to organize these sorts of variables better and maybe standardize a bit with spacings and such.