### PR TITLE
Fix build and burger menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Framework.dev is a knowledge base for different frontend frameworks
 
 ## Structure
 
-- `@framework.dev/system` is the themeable design system which powers all framework.dev sites
-- `@framework.dev/react` is the code for the react.framework.dev site
+- `@framework/system` is the themeable design system which powers all framework.dev sites
+- `@framework/react` is the code for the react.framework.dev site
 
 ## Running locally
 

--- a/amplify.yml
+++ b/amplify.yml
@@ -34,7 +34,7 @@ applications:
             - yarn build:system
         postBuild:
           commands:
-            - yarn workspace @framework.dev/system percy
+            - yarn workspace @framework/system percy
       artifacts:
         baseDirectory: dist
         files:

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
 	"license": "ISC",
 	"scripts": {
 		"dev": "run-p dev:* --print-label",
-		"dev:system": "yarn workspace @framework.dev/system dev",
-		"dev:react": "yarn workspace @framework.dev/react dev",
+		"dev:system": "yarn workspace @framework/system dev",
+		"dev:react": "yarn workspace @framework/react dev",
 		"build": "run-p build:* --print-label",
-		"build:system": "yarn workspace @framework.dev/system build",
-		"build:react": "yarn workspace @framework.dev/react build",
+		"build:system": "yarn workspace @framework/system build",
+		"build:react": "yarn workspace @framework/react build",
 		"prepare": "husky install",
 		"check": "tsc"
 	},
@@ -52,10 +52,12 @@
 		"vite-plugin-mdx": "^3.5.9"
 	},
 	"dependencies": {
+		"@reach/dialog": "^0.16.2",
 		"@babel/core": "^7.15.8",
 		"classnames": "^2.3.1",
 		"lodash": "^4.17.21",
 		"normalize.css": "^8.0.1",
+		"process": "^0.11.10",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
 		"the-new-css-reset": "^1.2.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@framework.dev/react",
+	"name": "@framework/react",
 	"version": "1.0.0",
 	"description": "",
 	"main": "index.js",

--- a/packages/react/snowpack.config.js
+++ b/packages/react/snowpack.config.js
@@ -1,1 +1,3 @@
-module.exports = require('../../snowpack.config')
+module.exports = {
+	extends: "../../snowpack.config.js",
+}

--- a/packages/react/src/components/mobile-nav.tsx
+++ b/packages/react/src/components/mobile-nav.tsx
@@ -1,0 +1,19 @@
+import {
+	MobileNav as MobileNavComponent,
+	MobileNavProps,
+} from "@framework/system/src/components/mobile-nav"
+import startCase from "lodash/startCase"
+
+type Props = MobileNavProps & { categories: string[] }
+
+export function MobileNav({ categories, ...props }: Props) {
+	return (
+		<MobileNavComponent {...props}>
+			{categories.map((category) => (
+				<a href={`/categories/${category}`} key={category}>
+					{startCase(category)}
+				</a>
+			))}
+		</MobileNavComponent>
+	)
+}

--- a/packages/react/src/data/books.ts
+++ b/packages/react/src/data/books.ts
@@ -1,4 +1,4 @@
-import { Book } from "@framework.dev/system/src/models/book"
+import { Book } from "@framework/system/src/models/book"
 
 export const bookTags = [
 	"state management",

--- a/packages/react/src/data/courses.ts
+++ b/packages/react/src/data/courses.ts
@@ -1,4 +1,4 @@
-import { Course } from "@framework.dev/system/src/models/course"
+import { Course } from "@framework/system/src/models/course"
 import codingAddict from "./assets/coding-addict.jpeg"
 import moshHamedani from "./assets/mosh-hamedani.jpeg"
 import newline from "./assets/newline.png"

--- a/packages/react/src/layouts/base.astro
+++ b/packages/react/src/layouts/base.astro
@@ -1,11 +1,11 @@
 ---
-import '@framework.dev/system/src/globals/global-styles';
+import '@framework/system/src/globals/global-styles';
 import { startCase } from 'lodash'
-import { fontHeadTags } from '@framework.dev/system/src/globals/font-import.mjs';
-import { sprinkles } from '@framework.dev/system/src/sprinkles/sprinkles.css';
-import { reactTheme } from '@framework.dev/system/src/themes/themes.css'
-import { Sidebar } from '@framework.dev/system/src/components/sidebar'
-import { MobileNav } from '@framework.dev/system/src/components/mobile-nav'
+import { fontHeadTags } from '@framework/system/src/globals/font-import.mjs';
+import { sprinkles } from '@framework/system/src/sprinkles/sprinkles.css';
+import { reactTheme } from '@framework/system/src/themes/themes.css'
+import { Sidebar } from '@framework/system/src/components/sidebar.tsx'
+import { MobileNav } from '../components/mobile-nav.tsx'
 const {title} = Astro.props
 const categories = ["courses"]
 const categoryLinks = categories.map(category => (
@@ -23,7 +23,7 @@ const categoryLinks = categories.map(category => (
   </head>
   <body class={sprinkles({ backgroundColor: "regular", layout: { mobile: "stack", desktop: "sidebar" } })} >
 		<Sidebar className={sprinkles({ display: { mobile: "none", desktop: "block" }})}>{categoryLinks}</Sidebar>
-		<MobileNav client:media="(max-width:1024px)" className={sprinkles({ display: { mobile: "flex", desktop: "none" }})}>{categoryLinks}</MobileNav>
+		<MobileNav client:media="(max-width:1024px)" className={sprinkles({ display: { mobile: "flex", desktop: "none" }})} categories={categories} />
 		<main class={sprinkles({ marginX: 64, marginY: 48 })}>
 			<slot />
 		</main>

--- a/packages/react/src/pages/categories/courses/formats/[format].astro
+++ b/packages/react/src/pages/categories/courses/formats/[format].astro
@@ -1,9 +1,9 @@
 ---
 import { startCase, kebabCase } from 'lodash'
-import { courseFormats } from '@framework.dev/system/src/models/course'
-import { PageHeader } from '@framework.dev/system/src/components/page-header'
-import { CourseCard } from '@framework.dev/system/src/components/course-card'
-import { sprinkles } from '@framework.dev/system/src/sprinkles/sprinkles.css'
+import { courseFormats } from '@framework/system/src/models/course'
+import { PageHeader } from '@framework/system/src/components/page-header.tsx'
+import { CourseCard } from '@framework/system/src/components/course-card.tsx'
+import { sprinkles } from '@framework/system/src/sprinkles/sprinkles.css'
 import { courses } from '../../../../data/courses'
 import BaseLayout from '../../../../layouts/base.astro'
 

--- a/packages/react/src/pages/categories/courses/index.astro
+++ b/packages/react/src/pages/categories/courses/index.astro
@@ -1,9 +1,9 @@
 ---
 import { courses } from '../../../data/courses'
 import BaseLayout from '../../../layouts/base.astro'
-import { CourseCard } from '@framework.dev/system/src/components/course-card'
-import { PageHeader } from '@framework.dev/system/src/components/page-header'
-import { sprinkles } from '@framework.dev/system/src/sprinkles/sprinkles.css'
+import { CourseCard } from '@framework/system/src/components/course-card.tsx'
+import { PageHeader } from '@framework/system/src/components/page-header.tsx'
+import { sprinkles } from '@framework/system/src/sprinkles/sprinkles.css'
 const title = "React Courses"
 ---
 <head>

--- a/packages/react/src/pages/categories/courses/levels/[level].astro
+++ b/packages/react/src/pages/categories/courses/levels/[level].astro
@@ -1,9 +1,9 @@
 ---
 import { startCase, kebabCase } from 'lodash'
-import { courseLevels } from '@framework.dev/system/src/models/course'
-import { PageHeader } from '@framework.dev/system/src/components/page-header'
-import { CourseCard } from '@framework.dev/system/src/components/course-card'
-import { sprinkles } from '@framework.dev/system/src/sprinkles/sprinkles.css'
+import { courseLevels } from '@framework/system/src/models/course'
+import { PageHeader } from '@framework/system/src/components/page-header.tsx'
+import { CourseCard } from '@framework/system/src/components/course-card.tsx'
+import { sprinkles } from '@framework/system/src/sprinkles/sprinkles.css'
 import { courses } from '../../../../data/courses'
 import BaseLayout from '../../../../layouts/base.astro'
 

--- a/packages/react/src/pages/categories/courses/payment/[payment].astro
+++ b/packages/react/src/pages/categories/courses/payment/[payment].astro
@@ -1,9 +1,9 @@
 ---
 import { startCase, kebabCase } from 'lodash'
-import { coursePaymentTypes } from '@framework.dev/system/src/models/course'
-import { PageHeader } from '@framework.dev/system/src/components/page-header'
-import { CourseCard } from '@framework.dev/system/src/components/course-card'
-import { sprinkles } from '@framework.dev/system/src/sprinkles/sprinkles.css'
+import { coursePaymentTypes } from '@framework/system/src/models/course'
+import { PageHeader } from '@framework/system/src/components/page-header.tsx'
+import { CourseCard } from '@framework/system/src/components/course-card.tsx'
+import { sprinkles } from '@framework/system/src/sprinkles/sprinkles.css'
 import { courses } from '../../../../data/courses'
 import BaseLayout from '../../../../layouts/base.astro'
 

--- a/packages/react/src/pages/categories/courses/tags/[tag].astro
+++ b/packages/react/src/pages/categories/courses/tags/[tag].astro
@@ -2,9 +2,9 @@
 import { startCase, kebabCase } from 'lodash'
 import { courses, courseTags } from '../../../../data/courses'
 import BaseLayout from '../../../../layouts/base.astro'
-import { PageHeader } from '@framework.dev/system/src/components/page-header'
-import { CourseCard } from '@framework.dev/system/src/components/course-card'
-import { sprinkles } from '@framework.dev/system/src/sprinkles/sprinkles.css'
+import { PageHeader } from '@framework/system/src/components/page-header.tsx'
+import { CourseCard } from '@framework/system/src/components/course-card.tsx'
+import { sprinkles } from '@framework/system/src/sprinkles/sprinkles.css'
 
 export function getStaticPaths() {
 	return courseTags.map(tag => ({

--- a/packages/system/package.json
+++ b/packages/system/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@framework.dev/system",
+	"name": "@framework/system",
 	"version": "1.0.0",
 	"description": "",
 	"main": "index.ts",
@@ -9,10 +9,5 @@
 		"dev": "start-storybook -p 6006",
 		"build": "build-storybook -o dist",
 		"percy": "percy storybook ./dist"
-	},
-	"dependencies": {
-		"@reach/dialog": "^0.16.2",
-		"typescript": "^4.4.4"
-	},
-	"devDependencies": {}
+	}
 }

--- a/packages/system/src/components/mobile-nav.tsx
+++ b/packages/system/src/components/mobile-nav.tsx
@@ -28,7 +28,7 @@ export function MobileNav({
 }: MobileNavProps) {
 	const [menuState, setMenuState] = useState(initialMenuState)
 	useEffect(() => {
-		if (menuState === "opening") setImmediate(() => setMenuState("open"))
+		if (menuState === "opening") setTimeout(() => setMenuState("open"), 0)
 	}, [menuState])
 	return (
 		<nav className={classNames(className, mobileNavStyle)} {...props}>

--- a/snowpack.config.js
+++ b/snowpack.config.js
@@ -1,7 +1,6 @@
 module.exports = {
 	workspaceRoot: __dirname,
 	plugins: ["@vanilla-extract/snowpack-plugin"],
-	exclude: ["**/node_modules/**/*", "**/*.stories.tsx"],
 	packageOptions: {
 		knownEntrypoints: [
 			"classnames",
@@ -11,5 +10,11 @@ module.exports = {
 			"the-new-css-reset/css/reset.css",
 			"normalize.css",
 		],
+		env: {
+			NODE_ENV: true,
+		},
+	},
+	alias: {
+		"@framework/system": "../system",
 	},
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
 		"esModuleInterop": true,
 		"noEmit": true,
 		"isolatedModules": true,
-		"jsx": "preserve"
+		"jsx": "preserve",
+		"resolveJsonModule": true
 	}
 }


### PR DESCRIPTION
Resolves #40

It turns out that Snowpack and Astro don't handle monorepos very well, so in this commit I worked through various bugs:

1. Removed the dot character from the package names. While this is valid in NodeJS it isn't well-handled by some Snowpack parsers
2. Made TSX imports explicit in Astro files. This is technically required for Astro, it was just sort of working in some cases by accident without it before.
3. Move all dependencies to the top level. Scoped dependencies don't get processed correctly by Snowpack, so for now we have to install everything in the root package.json
4. Created a shim for the mobile nav that lives in the astro project. Astro doesn't like client entrypoints being outside the src directory of the project