### PR TITLE
Hide badges from Percy to avoid thrashing

### DIFF
--- a/packages/system/.storybook/main.js
+++ b/packages/system/.storybook/main.js
@@ -17,6 +17,13 @@ module.exports = {
 	async previewHead(head) {
 		const { fontHeadTags } = await import("../src/globals/font-import.mjs")
 		return `
+		<style>
+			@media only percy {
+				.hide-in-percy {
+					visibility: hidden;
+				}
+			}
+		</style>
 			${head}
 			${fontHeadTags}
 		`

--- a/packages/system/src/components/library-card.tsx
+++ b/packages/system/src/components/library-card.tsx
@@ -13,6 +13,7 @@ import {
 	libraryCardStyle,
 } from "./library-card.css"
 import { Tag } from "./tag"
+import classnames from "classnames"
 
 export type LibraryCardProps = React.ComponentPropsWithoutRef<"article"> & {
 	headingTag: "h1" | "h2" | "h3" | "h4" | "h5" | "h6"
@@ -62,7 +63,7 @@ export function LibraryCard({
 			</div>
 			<div className={libraryCardBodyStyle}>{library.description}</div>
 			<div className={libraryCardSpacerStyle} />
-			<footer className={libraryCardFooterStyle}>
+			<footer className={classnames(libraryCardFooterStyle, "hide-in-percy")}>
 				<Badge
 					data={`https://img.shields.io/github/stars/${library.gitHubRepo}?style=flat&logo=github`}
 				/>


### PR DESCRIPTION
Badges don't always render and when they do they might have different numbers. This causes irrelevant diffs in Percy. This code should hide the badges from the Percy snapshotter