### PR TITLE
Improve badge performance by treating them as images

### DIFF
--- a/packages/system/src/components/library-card.tsx
+++ b/packages/system/src/components/library-card.tsx
@@ -67,9 +67,6 @@ export function LibraryCard({
 					data={`https://img.shields.io/github/stars/${library.gitHubRepo}?style=flat&logo=github`}
 				/>
 				<Badge
-					data={`https://img.shields.io/stackexchange/stackoverflow/t/${library.npmPackage}?style=flat&logo=stackoverflow&label=questions&link=https://stackoverflow.com/search?q=${library.npmPackage}`}
-				/>
-				<Badge
 					data={`https://img.shields.io/npm/dm/${library.npmPackage}?style=flat&logo=npm&link=https://www.npmjs.com/package/${library.npmPackage}`}
 				/>
 				<Badge
@@ -81,11 +78,5 @@ export function LibraryCard({
 }
 
 function Badge({ data }: { data: string }) {
-	return (
-		<object
-			className={libraryCardBadgeStyle}
-			type="image/svg+xml"
-			data={data}
-		/>
-	)
+	return <img className={libraryCardBadgeStyle} src={data} />
 }


### PR DESCRIPTION
It turns out that <object> tags are really really slow if you have a lot of them. This does mean that radically changing the style of the badges is out of our reach, we would have to download and keep the data ourselves