### PR TITLE
Fix capitalization of mixed-case values like "graphQL"

### DIFF
--- a/packages/system/src/util/string-utils.ts
+++ b/packages/system/src/util/string-utils.ts
@@ -27,7 +27,10 @@ export function serializeFieldValue(inputValue: string) {
 }
 
 export function formatFieldValue(inputValue: string) {
-	return titleCase(inputValue)
+	const titleCased = titleCase(inputValue)
+	// Capitalize first letter to work around edge cases with the titleCase
+	// algorithm not working correctly on single-word mixed-case values
+	return titleCased.charAt(0).toUpperCase() + titleCased.slice(1)
 }
 
 export function deserializeFieldName(inputValue: string) {


### PR DESCRIPTION


## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change

Fix the capitalization of mixed-case terms or terms with punctuation in thems such as "graphQL" or "react.js". The titleCase utility doesn't capitalize them properly by itself.

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

<!-- Always fill in -->

- [ ] I have added a line to the [changelog](../CHANGELOG.md) with the current
      date, change, PR number and author

<!-- Delete if your change is not a bug fix -->

- [x] This fix resolves #127
- [x] The changes follow the [contributing guidelines](../CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors
