### PR TITLE
fix the resource to which the "View all tools" link should lead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- [2022-03-10] Fix the link "View all tools" on the homepage
+  [\#171](https://github.com/thisdot/framework.dev/pull/171)
+  ([RinatValiullov](https://github.com/RinatValiullov))
 - [2021-03-04] Add initial content for Angular
   [\#165](https://github.com/thisdot/framework.dev/pull/165)
   ([brettzeidler](https://github.com/brettzeidler))

--- a/packages/system/src/components/homepage/latest-tools.tsx
+++ b/packages/system/src/components/homepage/latest-tools.tsx
@@ -16,7 +16,7 @@ export function LatestTools({ className, tools, ...props }: LatestToolsProps) {
 		<ResourceList
 			className={classNames(className, latestToolsStyle)}
 			title="Latest tools"
-			viewAll={{ title: "View all tools", href: "/categories/blogs" }}
+			viewAll={{ title: "View all tools", href: "/categories/tools" }}
 			items={randromTools.map((tool) => {
 				return {
 					image: tool.image,


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change

Fixed the resource to which the "View all tools" link on the home page should lead. Changed `"/categories/blogs"` to `"/categories/tools"`

## Checklist

- [x] I have added a line to the [changelog](../CHANGELOG.md) with the current
      date, change, PR number and author

- [ ] This fix resolves #<!-- replace with issue number -->
- [x] The changes follow the [contributing guidelines](../CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors