### PR TITLE
Add drop shadow to feature highlights on homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- [2021-03-11] Add drop shadow to feature highlights
+  [\#174](https://github.com/thisdot/framework.dev/pull/174)
+  ([jbachhardie](https://github.com/jbachhardie))
 - [2022-03-10] Fix the link "View all tools" on the homepage
   [\#171](https://github.com/thisdot/framework.dev/pull/171)
   ([RinatValiullov](https://github.com/RinatValiullov))

--- a/packages/system/src/components/homepage/hero.css.ts
+++ b/packages/system/src/components/homepage/hero.css.ts
@@ -135,3 +135,7 @@ export const heroFeatureHighlightTitleStyle = sprinkles({
 	textStyle: "bodyShort1",
 	fontWeight: "bold",
 })
+
+export const heroFeatureHighlightIconStyle = style({
+	filter: "drop-shadow(0px 0px 1px rgba(0, 0, 0, 0.2)) drop-shadow(0px 8px 17px rgba(0, 0, 0, 0.07)) drop-shadow(0px 2.92013px 6.20528px rgba(0, 0, 0, 0.0482987)) drop-shadow(0px 1.41767px 3.01255px rgba(0, 0, 0, 0.0389404)) drop-shadow(0px 0.694968px 1.47681px rgba(0, 0, 0, 0.0310596)) drop-shadow(0px 0.274791px 0.583932px rgba(0, 0, 0, 0.0217013))",
+})

--- a/packages/system/src/components/homepage/hero.tsx
+++ b/packages/system/src/components/homepage/hero.tsx
@@ -14,6 +14,7 @@ import {
 	heroFeatureHighlightRowStyle,
 	heroFeatureHighlightStyle,
 	heroFeatureHighlightTitleStyle,
+	heroFeatureHighlightIconStyle
 } from "./hero.css"
 import { getBackgroundImage } from "./hero-images"
 import { sprinkles } from "../../sprinkles/sprinkles.css"
@@ -108,6 +109,7 @@ const BrowseFeatureHighlightIcon = () => (
 		viewBox="17 9 64 64"
 		fill="none"
 		xmlns="http://www.w3.org/2000/svg"
+		className={heroFeatureHighlightIconStyle}
 	>
 		<path
 			d="M81 41C81 58.6731 66.6731 73 49 73C31.3269 73 17 58.6731 17 41C17 23.3269 31.3269 9 49 9C66.6731 9 81 23.3269 81 41Z"
@@ -203,6 +205,7 @@ const SearchFeatureHighlightIcon = () => (
 		viewBox="0 0 64 64"
 		fill="none"
 		xmlns="http://www.w3.org/2000/svg"
+		className={heroFeatureHighlightIconStyle}
 	>
 		<path
 			d="M64 32C64 49.6731 49.6731 64 32 64C14.3269 64 0 49.6731 0 32C0 14.3269 14.3269 0 32 0C49.6731 0 64 14.3269 64 32Z"
@@ -265,6 +268,7 @@ const CompareFeatureHighlightIcon = () => (
 		viewBox="0 0 64 64"
 		fill="none"
 		xmlns="http://www.w3.org/2000/svg"
+		className={heroFeatureHighlightIconStyle}
 	>
 		<path
 			d="M64 32C64 49.6731 49.6731 64 32 64C14.3269 64 0 49.6731 0 32C0 14.3269 14.3269 0 32 0C49.6731 0 64 14.3269 64 32Z"


### PR DESCRIPTION
## Type of change

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change

Added missing drop shadows to the feature highlight images

## Checklist

- [x] I have added a line to the [changelog](../CHANGELOG.md) with the current
      date, change, PR number and author
- [x] This fix resolves #166 
- [x] The changes follow the [contributing guidelines](../CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors
