### PR TITLE
add padding to bottom of home page so it's not flush with window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Changelog
 
+- [2021-04-12] Added bottom padding to `homepageContentContainerStyle`
+  [\#183](https://github.com/thisdot/framework.dev/pull/183)
+  ([iaremarkus](https://github.com/iaremarkus))
 - [2021-03-18] Remove unused components and styles
   [\#177](https://github.com/thisdot/framework.dev/pull/177)
   ([jbachhardie](https://github.com/jbachhardie))
 - [2021-03-14] Add Redux Toolkit, RTK Query, Jotai, Valtio
   [\#169](https://github.com/thisdot/framework.dev/pull/169)
   ([phryneas](https://github.com/phryneas))
-- [2022-03-13] Add Bumbag, Chakra UI, React Spectrum, Hashicorp React Component, Windmill React UI, Reach UI for React
+- [2022-03-13] Add Bumbag, Chakra UI, React Spectrum, Hashicorp React Component,
+  Windmill React UI, Reach UI for React
   [\#175](https://github.com/thisdot/framework.dev/pull/175)
   ([sprabowo](https://github.com/sprabowo))
 - [2021-03-11] Add drop shadow to feature highlights
@@ -20,14 +24,14 @@
 - [2021-03-04] Add initial content for Angular
   [\#165](https://github.com/thisdot/framework.dev/pull/165)
   ([brettzeidler](https://github.com/brettzeidler))
-- [2021-03-04] Add message indicating to user if no results were found in a category
-  [\#164](https://github.com/thisdot/framework.dev/pull/164)
+- [2021-03-04] Add message indicating to user if no results were found in a
+  category [\#164](https://github.com/thisdot/framework.dev/pull/164)
   ([tvanantwerp](https://github.com/tvanantwerp))
 - [2021-02-02] Update homepage hero
   [\#163](https://github.com/thisdot/framework.dev/pull/163)
   ([jbachhardie](https://github.com/jbachhardie))
-- [2021-02-02] Add link to skip to content for screen readers and keyboard-only navigation
-  [\#162](https://github.com/thisdot/framework.dev/pull/162)
+- [2021-02-02] Add link to skip to content for screen readers and keyboard-only
+  navigation [\#162](https://github.com/thisdot/framework.dev/pull/162)
   ([tvanantwerp](https://github.com/tvanantwerp))
 - [2021-01-20] Update logo
   [\#156](https://github.com/thisdot/framework.dev/pull/156)
@@ -44,7 +48,7 @@
 - [2022-01-04] Fix trailing slashes on URLs
   [\#147](https://github.com/thisdot/framework.dev/pull/147)
   ([jbachhardie](https://github.com/jbachhardie))
-- [2021-12-22] Add components and content for home page 
+- [2021-12-22] Add components and content for home page
   [\#145](https://github.com/thisdot/framework.dev/pull/145)
   ([tvanantwerp](https://github.com/tvanantwerp))
 - [2021-12-15] Improve site accessibility for keyboard and screen reader users

--- a/packages/system/src/components/homepage/homepage.css.ts
+++ b/packages/system/src/components/homepage/homepage.css.ts
@@ -11,14 +11,17 @@ export const homepageContentContainerStyle = style([
 	{
 		gap: pxToRem(64),
 		paddingTop: pxToRem(64),
+		paddingBottom: pxToRem(64),
 		"@media": {
 			[breakpoints.tablet]: {
 				gap: pxToRem(96),
 				paddingTop: pxToRem(96),
+				paddingBottom: pxToRem(96),
 			},
 			[breakpoints.desktop]: {
 				gap: pxToRem(128),
 				paddingTop: pxToRem(128),
+				paddingBottom: pxToRem(128),
 			},
 		},
 	},


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change

Added bottom padding to the `homepageContentContainerStyle` which currently only had top padding. This resulted in the content being flush with the window at the bottom.

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

<!-- Always fill in -->

- [x] I have added a line to the [changelog](../CHANGELOG.md) with the current
      date, change, PR number and author

<!-- Delete if your change is not a bug fix -->

- [x] This fix resolves an issue with my OCD 😅
- [x] The changes follow the [contributing guidelines](../CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors