### PR TITLE
set a `maxHeight` on `resourceCardImageStyle`

### DIFF
--- a/packages/system/src/components/cards/resource-card.css.ts
+++ b/packages/system/src/components/cards/resource-card.css.ts
@@ -121,7 +121,7 @@ export const resourceCardBookImageDecoration = style({
 export const resourceCardImageStyle = style([
 	sprinkles({ borderRadius: 8 }),
 	{
-		maxHeight: "100%",
+		maxHeight: "180px",
 		selectors: {
 			[`${bookImageContainerStyle} &`]: {
 				borderRadius: 0,


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change

added a `maxHeight` to `resourceCardImageStyle` to keep the cards more consistently laid out

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

<!-- Always fill in -->

- [x] I have added a line to the [changelog](../CHANGELOG.md) with the current
      date, change, PR number and author

<!-- Delete if your change is not a bug fix -->

- [x] This fix resolves #178 
- [x] The changes follow the [contributing guidelines](../CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors

