### PR TITLE
Feature: add amplify config for landing site and angular/vue sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+- [2022-05-05] Add deploy configs
+  [\#194](https://github.com/thisdot/framework.dev/pull/194)
+  ([jesus4497](https://github.com/jesus4497))
 - [2022-05-05] Add new landing site package
   [\#193](https://github.com/thisdot/framework.dev/pull/193)
   ([jesus4497](https://github.com/jesus4497))

--- a/amplify.yml
+++ b/amplify.yml
@@ -60,6 +60,26 @@ applications:
         paths:
           - ../../node_modules/**/*
           - ../../packages/*/node_modules/**/*
+  - appRoot: packages/landing-site
+    frontend:
+      phases:
+        preBuild:
+          commands:
+            - cd ../..
+            - nvm install
+            - nvm use
+            - yarn install
+        build:
+          commands:
+            - yarn build:landing
+      artifacts:
+        baseDirectory: ../site/dist
+        files:
+          - "**/*"
+      cache:
+        paths:
+          - ../../node_modules/**/*
+          - ../../packages/*/node_modules/**/*
   - appRoot: packages/system
     frontend:
       phases:

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -1,0 +1,3 @@
+This folder must exist for now or Amplify won't deploy.
+
+Once we get around to deleting and recreating the Amplify configuration we can remove it.

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,0 +1,3 @@
+This folder must exist for now or Amplify won't deploy.
+
+Once we get around to deleting and recreating the Amplify configuration we can remove it.


### PR DESCRIPTION
## Type of change

- [ ] Content addition
- [ ] Bug fix
- [x] Behavior change

## Summary of change

Adding vue/angular folders for the deployments of both angular.framework.dev and vue.framework.dev, plus adding amplify config for the landing site

## Checklist

- [x] I have added a line to the [changelog](../CHANGELOG.md) with the current
      date, change, PR number and author
- [x] I have confirmed with a maintainer that this change is desired and been
      given the go-ahead to work on it in the relevant issue discussion
- [x] The changes follow the [contributing guidelines](../CONTRIBUTING.md)
- [x] I have verified the change and the rest of the site works as expected
- [x] If the change introduces new components, these have been added to
      `packages/system/src/components` with a `.stories.tsx` file that
      adequately renders possible variations of each component.
