### PR TITLE
Fix: lower down fuzzy search threshold

### DIFF
--- a/packages/system/src/components/search/tag-filter.tsx
+++ b/packages/system/src/components/search/tag-filter.tsx
@@ -49,7 +49,7 @@ export function TagFilter<T extends string>({
 }: TagFilterProps<T>) {
 	const [tagSearch, setTagSearch] = useState("")
 	const searchIndex = useMemo(
-		() => new Fuse(options, { threshold: 0.8 }),
+		() => new Fuse(options, { threshold: 0.3 }),
 		[options]
 	)
 	const searchResults = take(


### PR DESCRIPTION
## Type of change

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change

Lowering down the threshold of the tag filter in order to make it less confusing and more precise.

## Checklist

- [x] This fix resolves #159 
- [x] The changes follow the [contributing guidelines](../CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors


