### PR TITLE
Style: fix both communities cards and link cards styles

### DIFF
--- a/packages/landing-site/src/constants/index.ts
+++ b/packages/landing-site/src/constants/index.ts
@@ -6,20 +6,17 @@ export const FRAMEWORK_RESOURCES: LinkCardProps[] = [
 		href: "https://angular.framework.dev/",
 		icon: "/icon-angular.svg",
 		backgroundColor: "#C3002F",
-		bigSize: true,
 	},
 	{
 		title: "React Resources",
 		href: "https://react.framework.dev/",
 		icon: "/icon-react.svg",
 		backgroundColor: "#00BCDA",
-		bigSize: true,
 	},
 	{
 		title: "Vue Resources",
 		href: "https://vue.framework.dev/",
 		icon: "/icon-vue.svg",
 		backgroundColor: "#41B883",
-		bigSize: true,
 	},
 ]

--- a/packages/system/src/components/cards/resource-card.css.ts
+++ b/packages/system/src/components/cards/resource-card.css.ts
@@ -93,7 +93,7 @@ export const resourceCardImageContainerStyle = style([
 		gridArea: "image",
 		overflow: "hidden",
 		display: "grid",
-		alignItems: "start",
+		alignItems: "center",
 		justifyItems: "center",
 		selectors: {
 			[`${titleFirst} &`]: {
@@ -106,7 +106,10 @@ export const resourceCardImageContainerStyle = style([
 				minHeight: pxToRem(144),
 			},
 		},
-	},
+	}, 
+	{
+		height: '12rem',
+	}
 ])
 
 export const bookImageContainerStyle = style({

--- a/packages/system/src/components/landing/hero.tsx
+++ b/packages/system/src/components/landing/hero.tsx
@@ -52,7 +52,7 @@ export function Hero({ className, heroText, linkCards, ...props }: HeroProps) {
 					)}
 				</div>
 				{linkCards && (
-					<LinkCardGroup cards={linkCards} className={linkCardGroupStyle} />
+					<LinkCardGroup bigSizeGroup cards={linkCards} className={linkCardGroupStyle} />
 				)}
 			</div>
 		</header>

--- a/packages/system/src/components/landing/link-card-group.tsx
+++ b/packages/system/src/components/landing/link-card-group.tsx
@@ -6,7 +6,8 @@ import { titleFirstCardGrid } from "./../cards/card-layouts.css"
 
 export interface LinkCardGroupProps
 	extends React.ComponentPropsWithoutRef<"div"> {
-	cards: LinkCardProps[]
+	cards: LinkCardProps[],
+	bigSizeGroup?: boolean,
 	columns?: number
 }
 
@@ -14,12 +15,13 @@ export function LinkCardGroup({
 	className,
 	cards,
 	columns,
+	bigSizeGroup = false,
 	...props
 }: LinkCardGroupProps) {
 	return (
 		<div className={classNames(className, titleFirstCardGrid)} {...props}>
 			{cards.map((card, index) => (
-				<LinkCard key={index} className={LinkCardGroupItemStyle} {...card} />
+				<LinkCard key={index} className={LinkCardGroupItemStyle} bigSize={bigSizeGroup} {...card} />
 			))}
 		</div>
 	)

--- a/packages/system/src/components/landing/resources-info-banner.tsx
+++ b/packages/system/src/components/landing/resources-info-banner.tsx
@@ -33,6 +33,7 @@ export function ResourcesInfoBanner({
 			<LinkCardGroupComponent
 				className={resourcesInfoBannerCardsStyle}
 				cards={cardResources}
+				bigSizeGroup={false}
 			/>
 		</div>
 	)


### PR DESCRIPTION
## Type of change

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change

Fixed the landing page resources cards where they weren't having different height sizes as shown in the figma, fixed as well the communities cards styles that were looking uneven from each other 

## Checklist

- [x] This fix resolves #219
- [x] The changes follow the [contributing guidelines](../CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors

