### PR TITLE
Add Harlem to list of Vue libraries

### DIFF
--- a/packages/site/src/data/vue/libraries.ts
+++ b/packages/site/src/data/vue/libraries.ts
@@ -438,4 +438,14 @@ export const libraries: Library<typeof libraryTags[number]>[] = [
 		description:
 			"Vue I18n is internationalization plugin for Vue.js",
 	},
+	{
+		name: "Harlem",
+		author: "Andrew Courtice",
+		gitHubRepo: "andrewcourtice/harlem",
+		npmPackage: "@harlem/core",
+		href: "https://harlemjs.com/",
+		image: "https://harlemjs.com/assets/images/logo-192.svg",
+		tags: ["state management", "Vue 3"],
+		description: "Simple, unopinionated, lightweight and extensible state management for Vue 3",
+	},
 ]


### PR DESCRIPTION
Adds the Harlem library to the list of Vue libraries.

## Type of change

- [x] Content addition
- [ ] Bug fix
- [ ] Behavior change

## Summary of change

Adds the Harlem state management library for Vue 3 to the list of libraries.

## Checklist

- [x] The changes follow the [contributing guidelines](../CONTRIBUTING.md)
- [x] I have searched all existing content and verified my additions are novel
      and unique
- [x] The content was added to the end of the appropriate data list
- [x] All required content fields are accurately populated
- [x] All items are tagged with all relevant tags

Wasn't requested, but here's a screenshot of the new card:
<img width="451" alt="image" src="https://user-images.githubusercontent.com/32229300/172444797-319fa4af-560c-4420-a2f3-2aad78bee58c.png">
