### PR TITLE
fix: show correct value in comparison table

### DIFF
--- a/packages/system/src/components/comparison-table/index.tsx
+++ b/packages/system/src/components/comparison-table/index.tsx
@@ -170,10 +170,10 @@ export function ComparisonTable({
 					</a>
 				</TD>
 				<TD>{library.author}</TD>
-				<TD>{formatPercentage(library.coverage) || "N/A"}</TD>
-				<TD>{formatNumber(library.downloads) || "N/A"}</TD>
-				<TD>{formatPercentage(library.health) || "N/A"}</TD>
-				<TD>{formatNumber(library.stars) || "N/A"}</TD>
+				<TD>{library.coverage ? formatPercentage(library.coverage) : "N/A"}</TD>
+				<TD>{library.downloads ? formatNumber(library.downloads) : "N/A"}</TD>
+				<TD>{library.health ? formatPercentage(library.health) : "N/A"}</TD>
+				<TD>{library.stars ? formatNumber(library.stars) : "N/A"}</TD>
 			</tr>
 		))
 	}

--- a/packages/system/src/components/comparison-table/utils.ts
+++ b/packages/system/src/components/comparison-table/utils.ts
@@ -23,5 +23,9 @@ export function formatPercentage(value: number) {
 }
 
 export function formatNumber(value: number) {
+	if (!value) {
+		return
+	}
+
 	return new Intl.NumberFormat().format(value)
 }

--- a/packages/system/src/components/comparison-table/utils.ts
+++ b/packages/system/src/components/comparison-table/utils.ts
@@ -23,7 +23,7 @@ export function formatPercentage(value: number) {
 }
 
 export function formatNumber(value: number) {
-	if (!value) {
+	if (value === undefined || value === null) {
 		return
 	}
 

--- a/packages/system/src/components/comparison-table/utils.ts
+++ b/packages/system/src/components/comparison-table/utils.ts
@@ -17,6 +17,10 @@ export function sortLibraries(
 }
 
 export function formatPercentage(value: number) {
+	if (value === undefined || value === null) {
+		return
+	}
+
 	return new Intl.NumberFormat([], {
 		style: "percent",
 	}).format(value)


### PR DESCRIPTION
## Type of change

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change

Fix value shown in the table when error in the API occurs

## Checklist

- [x] This fix resolves #228 
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors


