### PR TITLE
Fix: sorting in comparison table

### DIFF
--- a/packages/system/src/components/comparison-table/utils.ts
+++ b/packages/system/src/components/comparison-table/utils.ts
@@ -4,14 +4,24 @@ export function sortLibraries(
 	libraries: ILibrary[],
 	sortConfig: ISortConfig
 ): ILibrary[] {
-	return [...libraries].sort((a, b) => {
-		if (a[sortConfig.by] === b[sortConfig.by]) {
+	return libraries.sort((a, b) => {
+		const valueA =
+			typeof a[sortConfig.by] === "string"
+				? (a[sortConfig.by] as string).toUpperCase()
+				: a[sortConfig.by]
+
+		const valueB =
+			typeof b[sortConfig.by] === "string"
+				? (b[sortConfig.by] as string).toUpperCase()
+				: b[sortConfig.by]
+
+		if (valueA === valueB) {
 			return 0
 		}
 		if (sortConfig.asc) {
-			return a[sortConfig.by] > b[sortConfig.by] ? 1 : -1
+			return valueA > valueB ? 1 : -1
 		} else {
-			return b[sortConfig.by] > a[sortConfig.by] ? 1 : -1
+			return valueB > valueA ? 1 : -1
 		}
 	})
 }


### PR DESCRIPTION
## Type of change

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change

Fix sorting in comparison table that was case sensitive.

## Checklist

<!-- Delete if your change is not a bug fix -->

- [x] This fix resolves #238 
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors

