### PR TITLE
Fix: comparison table remove button stopped working

### DIFF
--- a/packages/system/src/components/comparison-table/utils.ts
+++ b/packages/system/src/components/comparison-table/utils.ts
@@ -4,7 +4,7 @@ export function sortLibraries(
 	libraries: ILibrary[],
 	sortConfig: ISortConfig
 ): ILibrary[] {
-	return libraries.sort((a, b) => {
+	return [...libraries].sort((a, b) => {
 		const valueA =
 			typeof a[sortConfig.by] === "string"
 				? (a[sortConfig.by] as string).toUpperCase()


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change

When the elements where sorting, it wasn't changing the reference of the array hence not triggering a re-render - Fixed

## Checklist

<!-- Delete if your change is not a bug fix -->

- [x] This fix resolves #242 
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors
