### PR TITLE
updated analytics key to env var

### DIFF
--- a/packages/landing-site/src/layouts/base.astro
+++ b/packages/landing-site/src/layouts/base.astro
@@ -28,7 +28,7 @@ const { title } = Astro.props
 		<meta name="theme-color" content="#ffffff">
 		<meta charset="UTF-8"/>
 		<!-- Global site tag (gtag.js) - Google Analytics -->
-		<script async src=`https://www.googletagmanager.com/gtag/js?id=${import.meta.env.SNOWPACK_PUBLIC_GOOGLE_ANALYTICS}`></script>
+		<script async src={`https://www.googletagmanager.com/gtag/js?id=${import.meta.env.SNOWPACK_PUBLIC_GOOGLE_ANALYTICS}`}></script>
 		{
 			import.meta.env.SNOWPACK_PUBLIC_ENVIRONMENT === "production" && 
 			<script>

--- a/packages/landing-site/src/layouts/base.astro
+++ b/packages/landing-site/src/layouts/base.astro
@@ -28,7 +28,7 @@ const { title } = Astro.props
 		<meta name="theme-color" content="#ffffff">
 		<meta charset="UTF-8"/>
 		<!-- Global site tag (gtag.js) - Google Analytics -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=G-33DWS64W1B"></script>
+		<script async src=`https://www.googletagmanager.com/gtag/js?id=${import.meta.env.SNOWPACK_PUBLIC_GOOGLE_ANALYTICS}`></script>
 		{
 			import.meta.env.SNOWPACK_PUBLIC_ENVIRONMENT === "production" && 
 			<script>
@@ -36,7 +36,7 @@ const { title } = Astro.props
 				function gtag(){dataLayer.push(arguments);}
 				gtag('js', new Date());
 
-				gtag('config', 'G-33DWS64W1B');
+				gtag('config', import.meta.env.SNOWPACK_PUBLIC_GOOGLE_ANALYTICS);
 			</script>
 		}
   </head>

--- a/packages/site/src/layouts/base.astro
+++ b/packages/site/src/layouts/base.astro
@@ -40,7 +40,7 @@ const navData = searchData.map(o => pick(o, ["name", "subCategories"]))
 		<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
 
 		<!-- Global site tag (gtag.js) - Google Analytics -->
-		<script async src=`https://www.googletagmanager.com/gtag/js?id=${import.meta.env.SNOWPACK_PUBLIC_GOOGLE_ANALYTICS}`></script>
+		<script async src={`https://www.googletagmanager.com/gtag/js?id=${import.meta.env.SNOWPACK_PUBLIC_GOOGLE_ANALYTICS}`}></script>
 		{
 			import.meta.env.SNOWPACK_PUBLIC_ENVIRONMENT === "production" && 
 			<script>

--- a/packages/site/src/layouts/base.astro
+++ b/packages/site/src/layouts/base.astro
@@ -40,7 +40,7 @@ const navData = searchData.map(o => pick(o, ["name", "subCategories"]))
 		<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
 
 		<!-- Global site tag (gtag.js) - Google Analytics -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=G-33DWS64W1B"></script>
+		<script async src=`https://www.googletagmanager.com/gtag/js?id=${import.meta.env.SNOWPACK_PUBLIC_GOOGLE_ANALYTICS}`></script>
 		{
 			import.meta.env.SNOWPACK_PUBLIC_ENVIRONMENT === "production" && 
 			<script>
@@ -48,7 +48,7 @@ const navData = searchData.map(o => pick(o, ["name", "subCategories"]))
 				function gtag(){dataLayer.push(arguments);}
 				gtag('js', new Date());
 
-				gtag('config', 'G-33DWS64W1B');
+				gtag('config', import.meta.env.SNOWPACK_PUBLIC_GOOGLE_ANALYTICS);
 			</script>
 		}
   </head>


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Content addition
- [ ] Bug fix
- [x] Behavior change

## Summary of change

Lifted the Google Tag Manager key to an env var stored in AWS at `SNOWPACK_PUBLIC_GOOGLE_ANALYTICS`.

## Checklist

<!-- Delete if your change is not a behaviour change -->

- [x] This change resolves https://github.com/orgs/thisdot/projects/10/views/8
- [x] I have confirmed with a maintainer that this change is desired and been
      given the go-ahead to work on it in the relevant issue discussion
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [ ] I have verified the change and the rest of the site works as expected
- [ ] If the change introduces new components, these have been added to
      `packages/system/src/components` with a `.stories.tsx` file that
      adequately renders possible variations of each component.
