### PR TITLE
Solidjs/community content

### DIFF
--- a/packages/site/src/data/solidjs/communities.ts
+++ b/packages/site/src/data/solidjs/communities.ts
@@ -27,4 +27,13 @@ export const communities: Community<typeof communityTags[number]>[] = [
     href: "https://www.reddit.com/r/solidjs/",
     tags: []
   },
+  {
+    name: "Events",
+    description:
+        "SolidJS Official Events.",
+    image: "https://assets.brandfolder.com/logo_images_v2/organizations/pjqost-dus1fs-bbjqqj/1549042902/Eventbrite_symbol_orange-400x400.png",
+    type: "Live Events",
+    href: "https://www.eventbrite.com/o/solidjs-official-events-47844139913",
+    tags: [],
+  },
 ]

--- a/packages/site/src/data/solidjs/communities.ts
+++ b/packages/site/src/data/solidjs/communities.ts
@@ -4,11 +4,27 @@ export const communityTags = [] as const
 
 export const communities: Community<typeof communityTags[number]>[] = [
   {
-    name: "test",
-    description: "test",
-    image: "https://github.com/reactiflux.png",
+    name: "Discord",
+    description: "Solid is a declarative reactive Javascript library for creating user interfaces. | 5809 members.",
+    image: "https://assets-global.website-files.com/6257adef93867e50d84d30e2/625e5fcef7ab80b8c1fe559e_Discord-Logo-Color.png",
     type: "discord",
-    href: "https://usehooks.com/",
+    href: "https://discord.com/invite/solidjs",
+    tags: []
+  },
+  {
+    name: "Twitter",
+    description: "Simple and performant reactivity for building user interfaces.",
+    image: "https://about.twitter.com/content/dam/about-twitter/en/brand-toolkit/brand-download-img-1.jpg.twimg.1920.jpg",
+    type: "twitter",
+    href: "https://twitter.com/solid_js",
+    tags: []
+  },
+  {
+    name: "r/SolidJS",
+    description: "Reddit's community for learning and developing web applications using SolidJS.",
+    image: "https://www.redditinc.com/assets/images/site/reddit-logo.png",
+    type: "reddit",
+    href: "https://www.reddit.com/r/solidjs/",
     tags: []
   },
 ]


### PR DESCRIPTION
## Type of change

- [x] Content addition
- [ ] Bug fix
- [ ] Behavior change

## Summary of change

As a visitor of the framework-specific Framework.dev site I would like to have the ability to see enough Communities content to keep me informed and find this site to be resourceful and useful.

## Checklist

- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have searched all existing content and verified my additions are novel
      and unique
- [x] The content was added to the end of the appropriate data list
- [x] All required content fields are accurately populated
- [ ] All items are tagged with all relevant tags

Closes: #292 
