### PR TITLE
limited google analytics to prod

### DIFF
--- a/packages/landing-site/src/layouts/base.astro
+++ b/packages/landing-site/src/layouts/base.astro
@@ -28,16 +28,19 @@ const { title } = Astro.props
 		<meta name="theme-color" content="#ffffff">
 		<meta charset="UTF-8"/>
 		<!-- Global site tag (gtag.js) - Google Analytics -->
-		<script async src={`https://www.googletagmanager.com/gtag/js?id=${import.meta.env.SNOWPACK_PUBLIC_GOOGLE_ANALYTICS || 'G-33DWS64W1B'}`}></script>
 		{
-			import.meta.env.SNOWPACK_PUBLIC_ENVIRONMENT === "production" && 
-			<script>
-				window.dataLayer = window.dataLayer || [];
-				function gtag(){dataLayer.push(arguments);}
-				gtag('js', new Date());
+			import.meta.env.SNOWPACK_PUBLIC_ENVIRONMENT === "production" && (
+			<>
+				<script async src={`https://www.googletagmanager.com/gtag/js?id=${import.meta.env.SNOWPACK_PUBLIC_GOOGLE_ANALYTICS}`}></script>
+				<script>
+					window.dataLayer = window.dataLayer || [];
+					function gtag(){dataLayer.push(arguments);}
+					gtag('js', new Date());
 
-				gtag('config', import.meta.env.SNOWPACK_PUBLIC_GOOGLE_ANALYTICS || 'G-33DWS64W1B');
-			</script>
+					gtag('config', import.meta.env.SNOWPACK_PUBLIC_GOOGLE_ANALYTICS);
+				</script>
+			</>
+			)
 		}
   </head>
   <body >

--- a/packages/site/src/layouts/base.astro
+++ b/packages/site/src/layouts/base.astro
@@ -38,16 +38,19 @@ const navData = searchData.map(o => pick(o, ["name", "subCategories"]))
 		<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
 
 		<!-- Global site tag (gtag.js) - Google Analytics -->
-		<script async src={`https://www.googletagmanager.com/gtag/js?id=${import.meta.env.SNOWPACK_PUBLIC_GOOGLE_ANALYTICS || 'G-33DWS64W1B'}`}></script>
 		{
-			import.meta.env.SNOWPACK_PUBLIC_ENVIRONMENT === "production" && 
-			<script>
-				window.dataLayer = window.dataLayer || [];
-				function gtag(){dataLayer.push(arguments);}
-				gtag('js', new Date());
+			import.meta.env.SNOWPACK_PUBLIC_ENVIRONMENT === "production" && (
+			<>
+				<script async src={`https://www.googletagmanager.com/gtag/js?id=${import.meta.env.SNOWPACK_PUBLIC_GOOGLE_ANALYTICS}`}></script>
+				<script>
+					window.dataLayer = window.dataLayer || [];
+					function gtag(){dataLayer.push(arguments);}
+					gtag('js', new Date());
 
-				gtag('config', import.meta.env.SNOWPACK_PUBLIC_GOOGLE_ANALYTICS || 'G-33DWS64W1B');
-			</script>
+					gtag('config', import.meta.env.SNOWPACK_PUBLIC_GOOGLE_ANALYTICS);
+				</script>
+			</>
+			)
 		}
   </head>
   <body class={classNames(sprinkles({ backgroundColor: "surface1", height: "full" }), bodyWithNav)} >


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Content addition
- [ ] Bug fix
- [x] Behavior change

## Summary of change

- Reverts adding a fallback to google analytics as each site's analytics ID is dynamically added and never the same
- Limits the google analytics to only setup in prod

## Checklist

<!-- Delete if your change is not a behaviour change -->

- [ ] This change resolves #<!-- replace with issue number -->
- [x] I have confirmed with a maintainer that this change is desired and been
      given the go-ahead to work on it in the relevant issue discussion
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [ ] I have verified the change and the rest of the site works as expected
- [ ] If the change introduces new components, these have been added to
      `packages/system/src/components` with a `.stories.tsx` file that
      adequately renders possible variations of each component.
