### PR TITLE
Add blogs content for framework

### DIFF
--- a/packages/site/src/data/solidjs/blogs.ts
+++ b/packages/site/src/data/solidjs/blogs.ts
@@ -4,7 +4,7 @@ export const blogTags = [] as const
 
 export const blogs: Blog<typeof blogTags[number]>[] = [
 	{
-		title: "Ryan Carniatos' blog",
+		title: "Ryan Carniato on dev.to",
 		author: "Ryan Carniato",
 		description:
 			"Frontend performance enthusiast and Fine-Grained Reactivity super fan. Author of the SolidJS UI library and MarkoJS Core Team Member.",

--- a/packages/site/src/data/solidjs/blogs.ts
+++ b/packages/site/src/data/solidjs/blogs.ts
@@ -26,7 +26,7 @@ export const blogs: Blog<typeof blogTags[number]>[] = [
 		author: "Nick Scialli",
 		description:
 			"I'm Nick Scialli, a software engineer with 14+ years of experience currently working as a senior UI engineer at Microsoft. I am a full stack developer with a focus on front-end technologies like JavaScript, Typescript, and React.",
-		image: "https://github.com/ryansolid.png",
+		image: "https://github.com/nas5w.png",
 		href: "https://typeofnan.dev/solid-js-feels-like-what-i-always-wanted-react-to-be/",
 		tags: [],
 	},

--- a/packages/site/src/data/solidjs/blogs.ts
+++ b/packages/site/src/data/solidjs/blogs.ts
@@ -4,11 +4,30 @@ export const blogTags = [] as const
 
 export const blogs: Blog<typeof blogTags[number]>[] = [
 	{
-	  title: "test",
-	  author: "test",
-	  description: "test.",
-	  image: "https://github.com/uidotdev.png",
-	  href: "https://ui.dev/blog/",
-	  tags: []
+		title: "Ryan Carniatos' blog",
+		author: "Ryan Carniato",
+		description:
+			"Frontend performance enthusiast and Fine-Grained Reactivity super fan. Author of the SolidJS UI library and MarkoJS Core Team Member.",
+		image: "https://github.com/ryansolid.png",
+		href: "https://dev.to/ryansolid",
+		tags: [],
+	},
+	{
+		title: "Ryan Carniatos' blog",
+		author: "Ryan Carniato",
+		description:
+			"FrontEnd JS Performance Enthusiast and Long Time Super Fan of Fine Grained Reactive Programming. Author of SolidJS UI Library.",
+		image: "https://github.com/ryansolid.png",
+		href: "https://admin.indepth.dev/author/ryan-carniato/",
+		tags: [],
+	},
+	{
+		title: "Solid.js feels like what I always wanted React to be",
+		author: "Nick Scialli",
+		description:
+			"I'm Nick Scialli, a software engineer with 14+ years of experience currently working as a senior UI engineer at Microsoft. I am a full stack developer with a focus on front-end technologies like JavaScript, Typescript, and React.",
+		image: "https://github.com/ryansolid.png",
+		href: "https://typeofnan.dev/solid-js-feels-like-what-i-always-wanted-react-to-be/",
+		tags: [],
 	},
 ]


### PR DESCRIPTION
## Type of change

Closes #296

There are currently only two blogs dedicated to solidjs and they belong to the libraries' author, the other blogs i could find had maybe just one or two articles on solidjs, added the one i could find.

- [x] Content addition
- [ ] Bug fix
- [ ] Behavior change

