### PR TITLE
fixed script rendering for analytics

### DIFF
--- a/packages/landing-site/src/layouts/base.astro
+++ b/packages/landing-site/src/layouts/base.astro
@@ -29,9 +29,11 @@ const { title } = Astro.props
 		<meta charset="UTF-8"/>
 		<!-- Global site tag (gtag.js) - Google Analytics -->
 		{
-			import.meta.env.SNOWPACK_PUBLIC_ENVIRONMENT === "production" && (
-			<>
+			import.meta.env.SNOWPACK_PUBLIC_ENVIRONMENT === "production" &&
 				<script async src={`https://www.googletagmanager.com/gtag/js?id=${import.meta.env.SNOWPACK_PUBLIC_GOOGLE_ANALYTICS}`}></script>
+		}
+		{
+			import.meta.env.SNOWPACK_PUBLIC_ENVIRONMENT === "production" &&
 				<script>
 					window.dataLayer = window.dataLayer || [];
 					function gtag(){dataLayer.push(arguments);}
@@ -39,8 +41,6 @@ const { title } = Astro.props
 
 					gtag('config', import.meta.env.SNOWPACK_PUBLIC_GOOGLE_ANALYTICS);
 				</script>
-			</>
-			)
 		}
   </head>
   <body >

--- a/packages/site/src/layouts/base.astro
+++ b/packages/site/src/layouts/base.astro
@@ -39,9 +39,11 @@ const navData = searchData.map(o => pick(o, ["name", "subCategories"]))
 
 		<!-- Global site tag (gtag.js) - Google Analytics -->
 		{
-			import.meta.env.SNOWPACK_PUBLIC_ENVIRONMENT === "production" && (
-			<>
+			import.meta.env.SNOWPACK_PUBLIC_ENVIRONMENT === "production" &&
 				<script async src={`https://www.googletagmanager.com/gtag/js?id=${import.meta.env.SNOWPACK_PUBLIC_GOOGLE_ANALYTICS}`}></script>
+		}
+		{
+			import.meta.env.SNOWPACK_PUBLIC_ENVIRONMENT === "production" &&
 				<script>
 					window.dataLayer = window.dataLayer || [];
 					function gtag(){dataLayer.push(arguments);}
@@ -49,8 +51,6 @@ const navData = searchData.map(o => pick(o, ["name", "subCategories"]))
 
 					gtag('config', import.meta.env.SNOWPACK_PUBLIC_GOOGLE_ANALYTICS);
 				</script>
-			</>
-			)
 		}
   </head>
   <body class={classNames(sprinkles({ backgroundColor: "surface1", height: "full" }), bodyWithNav)} >


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Content addition
- [ ] Bug fix
- [ ] Behavior change

## Summary of change

Resolves a rendering issue in prod that wasn't visible locally by correcting how the conditional script tags appear.

## Checklist

<!-- Delete if your change is not a behaviour change -->

- [ ] This change resolves #<!-- replace with issue number -->
- [ ] I have confirmed with a maintainer that this change is desired and been
      given the go-ahead to work on it in the relevant issue discussion
- [ ] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [ ] I have verified the change and the rest of the site works as expected
- [ ] If the change introduces new components, these have been added to
      `packages/system/src/components` with a `.stories.tsx` file that
      adequately renders possible variations of each component.
