### PR TITLE
Fix: Add correct link for Reactiflux community

### DIFF
--- a/packages/site/src/data/react/communities.ts
+++ b/packages/site/src/data/react/communities.ts
@@ -6,10 +6,10 @@ export const communities: Community<typeof communityTags[number]>[] = [
 	{
 		name: "Reactiflux",
 		description:
-			"A chat community of 147,000+ React JS, React Native, Redux, Jest, Relay and GraphQL developers. They hold Q&A’s with Facebook Engineers and other developers in the community, both on Discord and Twitter.",
+			"A chat community of 170,000+ React JS, React Native, Redux, Jest, Relay and GraphQL developers. They hold Q&A’s with Facebook Engineers and other developers in the community, both on Discord and Twitter.",
 		image: "https://github.com/reactiflux.png",
 		type: "discord",
-		href: "https://usehooks.com/",
+		href: "https://www.reactiflux.com/",
 		tags: [],
 	},
 	{


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [x] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change

Updated the headline and link to Reactiflux community

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

<!-- Delete if your change is not a content addition -->

- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have searched all existing content and verified my additions are novel
      and unique
- [x] The content was added to the end of the appropriate data list
- [x] All required content fields are accurately populated
- [x] All items are tagged with all relevant tags

<!-- Delete if your change is not a bug fix -->

- [x] This fix resolves #321 
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors

