### PR TITLE
feat: adding this dot content to all framework sites

### DIFF
--- a/packages/site/src/data/angular/blogs.ts
+++ b/packages/site/src/data/angular/blogs.ts
@@ -9,7 +9,7 @@ export const blogs: Blog<typeof blogTags[number]>[] = [
 		description:
 			"Variety of topics related to Angular, written by the team at This Dot",
 		image: "https://github.com/thisdot.png",
-		href: "https://www.thisdot.co/blog?filter=Angular#result",
+		href: "https://www.thisdot.co/blog/?filter=Angular#result",
 		tags: [],
 	},
 	{
@@ -42,7 +42,8 @@ export const blogs: Blog<typeof blogTags[number]>[] = [
 	{
 		title: "Blog @ Ultimate Courses",
 		author: "Todd Motto",
-		description: "Todd Motto wrote hundreds of blog posts revolving around Angular and covering various topics explained in a concise, beginner-friendly way.",
+		description:
+			"Todd Motto wrote hundreds of blog posts revolving around Angular and covering various topics explained in a concise, beginner-friendly way.",
 		image:
 			"https://ultimatecourses.com/assets/logo-ef24a2d3b6a0febba9ff80a1b01d632db750feb083442d0071dff7426762e0c2.svg",
 		href: "https://ultimatecourses.com/blog/",

--- a/packages/site/src/data/angular/courses.ts
+++ b/packages/site/src/data/angular/courses.ts
@@ -17,7 +17,7 @@ export const courseTags = [
 	"A11Y",
 	"pipes",
 	"angular patterns",
-	"typescript"
+	"typescript",
 ] as const
 
 export const courses: Course<typeof courseTags[number]>[] = [
@@ -189,7 +189,8 @@ export const courses: Course<typeof courseTags[number]>[] = [
 		tags: ["A11Y", "javascript marathon"],
 	},
 	{
-		title: "A Guide to Advanced Angular Patterns (Route Guards, Pipes, Interceptors & more)",
+		title:
+			"A Guide to Advanced Angular Patterns (Route Guards, Pipes, Interceptors & more)",
 		author: "Rob Ocel",
 		image: "https://github.com/thisdot.png",
 		description:
@@ -203,7 +204,8 @@ export const courses: Course<typeof courseTags[number]>[] = [
 	{
 		title: "Decoded Frontend",
 		author: "Dmytro Mezhenskyi",
-		image: "https://yt3.ggpht.com/ytc/AKedOLTRAN09hQv5mKM-q_dPdOo57tg14n3qKnx-bQNu0Q=s88-c-k-c0x00ffffff-no-rj",
+		image:
+			"https://yt3.ggpht.com/ytc/AKedOLTRAN09hQv5mKM-q_dPdOo57tg14n3qKnx-bQNu0Q=s88-c-k-c0x00ffffff-no-rj",
 		description:
 			"Decoded Training is a series of video tutorials about Angular and generally about web development. New videos are published on a biweekly basis.",
 		paymentType: "free",
@@ -215,7 +217,8 @@ export const courses: Course<typeof courseTags[number]>[] = [
 	{
 		title: "Ultimate Courses",
 		author: "Todd Motto",
-		image: "https://ultimatecourses.com/assets/logo-ef24a2d3b6a0febba9ff80a1b01d632db750feb083442d0071dff7426762e0c2.svg",
+		image:
+			"https://ultimatecourses.com/assets/logo-ef24a2d3b6a0febba9ff80a1b01d632db750feb083442d0071dff7426762e0c2.svg",
 		description:
 			"Ultimate Courses has a collection of video courses covering beginner and advanced Angular, TypeScript, RxJS, and NgRX.",
 		paymentType: "paid",
@@ -223,5 +226,17 @@ export const courses: Course<typeof courseTags[number]>[] = [
 		format: "video",
 		href: "https://ultimatecourses.com/",
 		tags: ["RxJS", "typescript", "ngRx"],
+	},
+	{
+		title: "JS Drops",
+		author: "Various",
+		image: "https://github.com/thisdot.png",
+		description:
+			"JS Drops is a weekly series of online courses on Angular, React, TypeScript, GraphQL, and other topics in the JS ecosystem. Learn about leading web development technologies and concepts!",
+		paymentType: "free",
+		level: "intermediate",
+		format: "video",
+		href: "https://dropjs.com/",
+		tags: ["javascript marathon"],
 	},
 ]

--- a/packages/site/src/data/angular/libraries.ts
+++ b/packages/site/src/data/angular/libraries.ts
@@ -541,4 +541,15 @@ export const libraries: Library<typeof libraryTags[number]>[] = [
 		description:
 			"RxIDB is a library for storing and retrieving data from indexedDB databases, using an RxJS based API.",
 	},
+	{
+		name: "Route Config",
+		author: "This Dot Labs",
+		gitHubRepo: "thisdot/open-source",
+		npmPackage: "@this-dot/route-config",
+		href: "https://www.npmjs.com/package/@this-dot/route-config",
+		image: "https://github.com/thisdot.png",
+		tags: ["performance tools"],
+		description:
+			"Route Config is an Angular library that provides tools to easily set and access the properties defined in RouterModule configuration. It offers some built in tools that work out of the box but also is easily extensible via data property of Angular's Route configuration object.",
+	},
 ]

--- a/packages/site/src/data/angular/libraries.ts
+++ b/packages/site/src/data/angular/libraries.ts
@@ -552,4 +552,15 @@ export const libraries: Library<typeof libraryTags[number]>[] = [
 		description:
 			"Route Config is an Angular library that provides tools to easily set and access the properties defined in RouterModule configuration. It offers some built in tools that work out of the box but also is easily extensible via data property of Angular's Route configuration object.",
 	},
+	{
+		name: "Ng Utils",
+		author: "This Dot Labs",
+		gitHubRepo: "thisdot/open-source",
+		npmPackage: "@this-dot/ng-utils",
+		href: "https://www.npmjs.com/package/@this-dot/ng-utils",
+		image: "https://github.com/thisdot.png",
+		tags: ["performance tools"],
+		description:
+			"Ng Utils is a collection of Angular utils which we would like to continuously extend and improve.",
+	},
 ]

--- a/packages/site/src/data/angular/libraries.ts
+++ b/packages/site/src/data/angular/libraries.ts
@@ -563,4 +563,15 @@ export const libraries: Library<typeof libraryTags[number]>[] = [
 		description:
 			"Ng Utils is a collection of Angular utils which we would like to continuously extend and improve.",
 	},
+	{
+		name: "Cypress IndexedDB helpers ",
+		author: "This Dot Labs",
+		gitHubRepo: "thisdot/open-source",
+		npmPackage: "@this-dot/cypress-indexeddb",
+		href: "https://www.npmjs.com/package/@this-dot/cypress-indexeddb",
+		image: "https://github.com/thisdot.png",
+		tags: ["testing"],
+		description:
+			"Cypress IndexedDB helpers are a set of custom cypress commands that helps you handle indexedDB related operations in your Cypress tests.",
+	},
 ]

--- a/packages/site/src/data/angular/libraries.ts
+++ b/packages/site/src/data/angular/libraries.ts
@@ -564,7 +564,7 @@ export const libraries: Library<typeof libraryTags[number]>[] = [
 			"Ng Utils is a collection of Angular utils which we would like to continuously extend and improve.",
 	},
 	{
-		name: "Cypress IndexedDB helpers ",
+		name: "Cypress IndexedDB helpers",
 		author: "This Dot Labs",
 		gitHubRepo: "thisdot/open-source",
 		npmPackage: "@this-dot/cypress-indexeddb",

--- a/packages/site/src/data/angular/libraries.ts
+++ b/packages/site/src/data/angular/libraries.ts
@@ -530,4 +530,15 @@ export const libraries: Library<typeof libraryTags[number]>[] = [
 		description:
 			"Jest is a delightful JavaScript Testing Framework with a focus on simplicity.",
 	},
+	{
+		name: "RxIDB",
+		author: "This Dot Labs",
+		gitHubRepo: "thisdot/open-source",
+		npmPackage: "@this-dot/rxidb",
+		href: "https://www.npmjs.com/package/@this-dot/rxidb",
+		image: "https://github.com/thisdot.png",
+		tags: ["RxJS"],
+		description:
+			"RxIDB is a library for storing and retrieving data from indexedDB databases, using an RxJS based API.",
+	},
 ]

--- a/packages/site/src/data/react/blogs.ts
+++ b/packages/site/src/data/react/blogs.ts
@@ -3,28 +3,39 @@ import { Blog } from "@framework/system/src/models/blog"
 export const blogTags = [] as const
 
 export const blogs: Blog<typeof blogTags[number]>[] = [
-  {
-    title: "ui.dev",
-    author: "Tyler McGinnis",
-    description: "A JavaScript blog with a focus on React content.",
-    image: "https://github.com/uidotdev.png",
-    href: "https://ui.dev/blog/",
-    tags: []
-  },
-  {
-    title: "Kent C. Dodds' Blog",
-    author: "Kent C. Dodds",
-    description: "Renowned JavaScript and React educator, Kent C. Dodds, shares his React knowledge through his blog.",
-    image: "https://github.com/kentcdodds.png",
-    href: "https://kentcdodds.com/blog?q=react",
-    tags: []
-  },
-  {
-    title: "Robin Wieruch's Blog",
-    author: "Robin Wieruch",
-    description: "German software engineer, Robin Weiruch, shares a variety of posts on React and JavaScript.",
-    image: "https://github.com/rwieruch.png",
-    href: "https://www.robinwieruch.de/categories/react/",
-    tags: []
-  }
+	{
+		title: "ui.dev",
+		author: "Tyler McGinnis",
+		description: "A JavaScript blog with a focus on React content.",
+		image: "https://github.com/uidotdev.png",
+		href: "https://ui.dev/blog/",
+		tags: [],
+	},
+	{
+		title: "Kent C. Dodds' Blog",
+		author: "Kent C. Dodds",
+		description:
+			"Renowned JavaScript and React educator, Kent C. Dodds, shares his React knowledge through his blog.",
+		image: "https://github.com/kentcdodds.png",
+		href: "https://kentcdodds.com/blog?q=react",
+		tags: [],
+	},
+	{
+		title: "Robin Wieruch's Blog",
+		author: "Robin Wieruch",
+		description:
+			"German software engineer, Robin Weiruch, shares a variety of posts on React and JavaScript.",
+		image: "https://github.com/rwieruch.png",
+		href: "https://www.robinwieruch.de/categories/react/",
+		tags: [],
+	},
+	{
+		title: "This Dot Blog",
+		author: "This Dot Labs",
+		description:
+			"Variety of topics related to React, written by the team at This Dot",
+		image: "https://github.com/thisdot.png",
+		href: "https://www.thisdot.co/blog/?filter=ReactJS#result",
+		tags: [],
+	},
 ]

--- a/packages/site/src/data/react/communities.ts
+++ b/packages/site/src/data/react/communities.ts
@@ -375,4 +375,13 @@ export const communities: Community<typeof communityTags[number]>[] = [
 		href: "https://www.jsday.ie/",
 		tags: ["conferences"],
 	},
+	{
+		name: "React Meetup",
+		description:
+			"A This Dot Labs event where you can speak to React experts and ask questions in a small, welcoming group of community members. You can ask specific use case questions or even just network and chat about tech career advice!",
+		image: "https://github.com/thisdot.png",
+		type: "Live Events",
+		href: "https://www.reactjsmeetup.com/",
+		tags: ["meetups"],
+	},
 ]

--- a/packages/site/src/data/react/courses.ts
+++ b/packages/site/src/data/react/courses.ts
@@ -27,7 +27,7 @@ export const courseTags = [
 	"SSG",
 	"component design",
 	"apollo",
-	"faunaDB"
+	"faunaDB",
 ] as const
 
 export const courses: Course<typeof courseTags[number]>[] = [
@@ -314,7 +314,7 @@ export const courses: Course<typeof courseTags[number]>[] = [
 		level: "beginner",
 		format: "video",
 		href: "https://youtu.be/ecpvIo4NIoY",
-		tags: ["vite",  "javascript marathon"],
+		tags: ["vite", "javascript marathon"],
 	},
 	{
 		title: "1 Hour to Learn React",
@@ -350,7 +350,13 @@ export const courses: Course<typeof courseTags[number]>[] = [
 		level: "advanced",
 		format: "video",
 		href: "https://youtu.be/0Js5O5a4bQ4",
-		tags: ["graphQL", "authentication", "AWS", "data fetching", "javascript marathon"],
+		tags: [
+			"graphQL",
+			"authentication",
+			"AWS",
+			"data fetching",
+			"javascript marathon",
+		],
 	},
 	{
 		title: "An Introduction to Netlify with React",
@@ -386,7 +392,13 @@ export const courses: Course<typeof courseTags[number]>[] = [
 		level: "beginner",
 		format: "video",
 		href: "https://youtu.be/JmVdgtjGo5Q",
-		tags: ["graphQL", "data fetching", "component design", "apollo", "javascript marathon"],
+		tags: [
+			"graphQL",
+			"data fetching",
+			"component design",
+			"apollo",
+			"javascript marathon",
+		],
 	},
 	{
 		title: "Databases made easy in React with GraphQL and FaunaDB",
@@ -410,7 +422,16 @@ export const courses: Course<typeof courseTags[number]>[] = [
 		level: "beginner",
 		format: "interactive",
 		href: "https://themodern.dev/courses/build-a-fullstack-app-with-nextjs-supabase-and-prisma-322389284337222224",
-		tags: ["state management", "data fetching", "routing", "forms", "authentication", "hooks", "tailwind", "SSG"],
+		tags: [
+			"state management",
+			"data fetching",
+			"routing",
+			"forms",
+			"authentication",
+			"hooks",
+			"tailwind",
+			"SSG",
+		],
 	},
 	{
 		title: "Complete Intro to React, v7",
@@ -422,6 +443,26 @@ export const courses: Course<typeof courseTags[number]>[] = [
 		level: "beginner",
 		format: "video",
 		href: "https://frontendmasters.com/courses/complete-react-v7/",
-		tags: ["state management", "data fetching", "forms", "routing", "authentication", "hooks", "tailwind",],
+		tags: [
+			"state management",
+			"data fetching",
+			"forms",
+			"routing",
+			"authentication",
+			"hooks",
+			"tailwind",
+		],
+	},
+	{
+		title: "JS Drops",
+		author: "Various",
+		image: "https://github.com/thisdot.png",
+		description:
+			"JS Drops is a weekly series of online courses on React, TypeScript, GraphQL, and other topics in the JS ecosystem. Learn about leading web development technologies and concepts!",
+		paymentType: "free",
+		level: "intermediate",
+		format: "video",
+		href: "https://dropjs.com/",
+		tags: ["javascript marathon"],
 	},
 ]

--- a/packages/site/src/data/react/libraries.ts
+++ b/packages/site/src/data/react/libraries.ts
@@ -949,7 +949,7 @@ export const libraries: Library<typeof libraryTags[number]>[] = [
 			"Enzyme is a JavaScript Testing utility for React that makes it easier to test your React Components' output.",
 	},
 	{
-		name: "Cypress IndexedDB helpers ",
+		name: "Cypress IndexedDB helpers",
 		author: "This Dot Labs",
 		gitHubRepo: "thisdot/open-source",
 		npmPackage: "@this-dot/cypress-indexeddb",

--- a/packages/site/src/data/react/libraries.ts
+++ b/packages/site/src/data/react/libraries.ts
@@ -943,10 +943,20 @@ export const libraries: Library<typeof libraryTags[number]>[] = [
 		gitHubRepo: "enzymejs/enzyme",
 		npmPackage: "enzyme",
 		href: "https://enzymejs.github.io/enzyme/",
-		image:
-			"https://github.com/enzymejs.png",
+		image: "https://github.com/enzymejs.png",
 		tags: ["testing"],
 		description:
 			"Enzyme is a JavaScript Testing utility for React that makes it easier to test your React Components' output.",
+	},
+	{
+		name: "Cypress IndexedDB helpers ",
+		author: "This Dot Labs",
+		gitHubRepo: "thisdot/open-source",
+		npmPackage: "@this-dot/cypress-indexeddb",
+		href: "https://www.npmjs.com/package/@this-dot/cypress-indexeddb",
+		image: "https://github.com/thisdot.png",
+		tags: ["testing"],
+		description:
+			"Cypress IndexedDB helpers are a set of custom cypress commands that helps you handle indexedDB related operations in your Cypress tests.",
 	},
 ]

--- a/packages/site/src/data/vue/blogs.ts
+++ b/packages/site/src/data/vue/blogs.ts
@@ -31,4 +31,13 @@ export const blogs: Blog<typeof blogTags[number]>[] = [
 		href: "https://vueschool.io/articles/",
 		tags: [],
 	},
+	{
+		title: "This Dot Blog",
+		author: "This Dot Labs",
+		description:
+			"Variety of topics related to Vue, written by the team at This Dot",
+		image: "https://github.com/thisdot.png",
+		href: "https://www.thisdot.co/blog/?filter=VueJS#result",
+		tags: [],
+	},
 ]

--- a/packages/site/src/data/vue/courses.ts
+++ b/packages/site/src/data/vue/courses.ts
@@ -237,4 +237,16 @@ export const courses: Course<typeof courseTags[number]>[] = [
 		href: "https://youtu.be/wXFcRDsFSEU",
 		tags: ["Vue 2", "debugging", "javascript marathon"],
 	},
+	{
+		title: "JS Drops",
+		author: "Various",
+		image: "https://github.com/thisdot.png",
+		description:
+			"JS Drops is a weekly series of online courses on Vue, React, TypeScript, GraphQL, and other topics in the JS ecosystem. Learn about leading web development technologies and concepts!",
+		paymentType: "free",
+		level: "intermediate",
+		format: "video",
+		href: "https://dropjs.com/",
+		tags: ["javascript marathon"],
+	},
 ]

--- a/packages/site/src/data/vue/libraries.ts
+++ b/packages/site/src/data/vue/libraries.ts
@@ -500,7 +500,7 @@ export const libraries: Library<typeof libraryTags[number]>[] = [
 			"Jest is a delightful JavaScript Testing Framework with a focus on simplicity.",
 	},
 	{
-		name: "Cypress IndexedDB helpers ",
+		name: "Cypress IndexedDB helpers",
 		author: "This Dot Labs",
 		gitHubRepo: "thisdot/open-source",
 		npmPackage: "@this-dot/cypress-indexeddb",

--- a/packages/site/src/data/vue/libraries.ts
+++ b/packages/site/src/data/vue/libraries.ts
@@ -499,4 +499,15 @@ export const libraries: Library<typeof libraryTags[number]>[] = [
 		description:
 			"Jest is a delightful JavaScript Testing Framework with a focus on simplicity.",
 	},
+	{
+		name: "Cypress IndexedDB helpers ",
+		author: "This Dot Labs",
+		gitHubRepo: "thisdot/open-source",
+		npmPackage: "@this-dot/cypress-indexeddb",
+		href: "https://www.npmjs.com/package/@this-dot/cypress-indexeddb",
+		image: "https://github.com/thisdot.png",
+		tags: ["testing"],
+		description:
+			"Cypress IndexedDB helpers are a set of custom cypress commands that helps you handle indexedDB related operations in your Cypress tests.",
+	},
 ]

--- a/packages/site/src/data/vue/libraries.ts
+++ b/packages/site/src/data/vue/libraries.ts
@@ -510,4 +510,15 @@ export const libraries: Library<typeof libraryTags[number]>[] = [
 		description:
 			"Cypress IndexedDB helpers are a set of custom cypress commands that helps you handle indexedDB related operations in your Cypress tests.",
 	},
+	{
+		name: "Vue Route Guard",
+		author: "This Dot Labs",
+		gitHubRepo: "thisdot/open-source",
+		npmPackage: "@this-dot/vue-route-guard",
+		href: "https://www.npmjs.com/package/@this-dot/vue-route-guard",
+		image: "https://github.com/thisdot.png",
+		tags: ["routing"],
+		description:
+			"Vue Route Guard is an Vue library that wraps around the vue-router and extends it to provide helpful methods to handle page guards via token authorization and permissions.",
+	},
 ]


### PR DESCRIPTION
## Type of change

- [x] Content addition
- [ ] Bug fix
- [ ] Behavior change

## Summary of change
This PR is ensuring that all of This Dot Labs content has been added to the React, Vue and Angular sites. 

- [x] This dot blog as been added to all three sites
- [x] double checked to make sure that Modern web podcast was on the React, Vue and Angular sites.  
- [x] ensuring that all this dot meetup events have been added. Added the missing react meetup
- [x] adding JS Drops to the React, Vue and Angular sites.  
- [x] adding this dot labs rxidb library
- [x] adding this dot labs ng-utils
- [x] adding this dot labs route-config
- [x] adding this dot labs cypress helpers 
- [x] adding this dot vue route guard

closes #347 
## Checklist

- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have searched all existing content and verified my additions are novel
      and unique
- [x] The content was added to the end of the appropriate data list
- [x] All required content fields are accurately populated
- [x] All items are tagged with all relevant tags

