### PR TITLE
fix framer motion logo

### DIFF
--- a/packages/site/src/data/react/libraries.ts
+++ b/packages/site/src/data/react/libraries.ts
@@ -581,7 +581,7 @@ export const libraries: Library<typeof libraryTags[number]>[] = [
 		npmPackage: "framer-motion",
 		href: "https://www.framer.com/docs/",
 		image:
-			"https://user-images.githubusercontent.com/22095598/123793419-f5528800-d8e1-11eb-8c5f-e2dad45a9c81.png",
+			"https://camo.githubusercontent.com/179d66ab2b0321726c88a586c4ad38802e7113a3c98c6fd3f0156c01c98cfd14/68747470733a2f2f6672616d657275736572636f6e74656e742e636f6d2f696d616765732f34386861395a52396f5a51475136675a38595566456c50335430412e706e67",
 		tags: ["animation"],
 		description:
 			"Motion is a production-ready motion library for React from Framer. It brings declarative animations, effortless layout transitions and gestures while maintaining HTML and SVG semantics.",


### PR DESCRIPTION
## Type of change

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change

Before:
<img width="504" alt="Screen Shot 2022-10-29 at 12 48 18 PM" src="https://user-images.githubusercontent.com/1815379/198845875-53303028-f3e3-4123-95bb-e21c7e7ddad4.png">

After:
<img width="507" alt="Screen Shot 2022-10-29 at 12 48 30 PM" src="https://user-images.githubusercontent.com/1815379/198845878-e08431fe-f287-40bc-87ec-2b1e7251aa90.png">

## Checklist

- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors

