### PR TITLE
Keen UI logo missing fixes #363

### DIFF
--- a/packages/site/src/data/vue/libraries.ts
+++ b/packages/site/src/data/vue/libraries.ts
@@ -105,7 +105,7 @@ export const libraries: Library<typeof libraryTags[number]>[] = [
 		href: "https://josephuspaye.github.io/Keen-UI",
 		description:
 			"Keen UI is a Vue 2 UI library with a simple API, inspired by Google's Material Design.",
-		image: "",
+		image: "https://madewithnetworkfra.fra1.digitaloceanspaces.com/spatie-space-production/1157/keen.jpg",
 		tags: ["component library", "Vue 2"],
 	},
 	{


### PR DESCRIPTION
## Type of change

Keen UI logo missing fixes #363

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change

Keen UI logo was missing from libraries.ts in vue

## Checklist





<!-- Delete if your change is not a bug fix -->

- [x] This fix resolves #363
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [ ] I have verified the fix works and introduces no further errors


