### PR TITLE
fix: reducing size for framework icons on landing page

### DIFF
--- a/packages/system/src/globals/global-constants.tsx
+++ b/packages/system/src/globals/global-constants.tsx
@@ -10,7 +10,7 @@ export const FRAMEWORK_RESOURCES = (bigSize = false): LinkCardProps[] => [
 		title: "Angular Resources",
 		href: "https://angular.framework.dev/",
 		Icon(props) {
-			return <AngularIcon {...props} />
+			return <AngularIcon {...props} size="large" />
 		},
 		backgroundColor: "#C3002F",
 		bigSize,
@@ -19,7 +19,7 @@ export const FRAMEWORK_RESOURCES = (bigSize = false): LinkCardProps[] => [
 		title: "React Resources",
 		href: "https://react.framework.dev/",
 		Icon(props) {
-			return <ReactIcon {...props} />
+			return <ReactIcon {...props} size="large" />
 		},
 		backgroundColor: "#00BCDA",
 		bigSize,
@@ -28,7 +28,7 @@ export const FRAMEWORK_RESOURCES = (bigSize = false): LinkCardProps[] => [
 		title: "Vue Resources",
 		href: "https://vue.framework.dev/",
 		Icon(props) {
-			return <VueIcon {...props} />
+			return <VueIcon {...props} size="large" />
 		},
 		backgroundColor: "#41B883",
 		bigSize,
@@ -46,7 +46,7 @@ export const FRAMEWORK_RESOURCES = (bigSize = false): LinkCardProps[] => [
 		title: "Qwik Resources",
 		href: "https://qwik.framework.dev/",
 		Icon(props) {
-			return <QwikIcon {...props} />
+			return <QwikIcon {...props} size="large" />
 		},
 		backgroundColor: "#AC7EF4",
 		bigSize,


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change
I set the size for all framework icons to large instead of full for the landing page.

## Before
<img width="1171" alt="Screen Shot 2022-11-02 at 10 18 30 AM" src="https://user-images.githubusercontent.com/67210629/199557589-655531fa-61bc-45b8-b10f-e229df3a10f2.png">

## After
<img width="1208" alt="Screen Shot 2022-11-02 at 10 18 44 AM" src="https://user-images.githubusercontent.com/67210629/199557639-09f57159-2dc7-4b85-9e85-c8ba25bf0766.png">


## Checklist


- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have searched all existing content and verified my additions are novel
      and unique
- [x] This fix resolves #401 
- [x] I have verified the fix works and introduces no further errors


