### PR TITLE
chore: updating page title for all framework sites

### DIFF
--- a/packages/site/src/pages/index.astro
+++ b/packages/site/src/pages/index.astro
@@ -40,7 +40,7 @@ const resourceCards = FRAMEWORK_RESOURCES().filter(
 <head>
 	{`<script type="application/ld+json">${JSON.stringify(searchableWebsiteStructuredData)}</script>`}
 </head>
-<BaseLayout title="Featured resources" className={scrollable}>
+<BaseLayout title={`Featured Resources | ${import.meta.env.SNOWPACK_PUBLIC_FRAMEWORK}.framework.dev`} className={scrollable}>
 	<Homepage
 		librariesTitle={`Featured ${formatFieldName(import.meta.env.SNOWPACK_PUBLIC_FRAMEWORK)} Libraries`}
 		libraries={libraries?.data}


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Content addition
- [ ] Bug fix
- [ ] Behavior change
- [x] updating page title

## Summary of change
I have edited the title for all framework sites in the `index.astro` file. 
The title now follows this format: Featured Resources | name-of-framework.framework.dev
closes #408 

## Title page Before changes were applied
<img width="277" alt="Screen Shot 2022-11-03 at 9 36 07 AM" src="https://user-images.githubusercontent.com/67210629/199780169-cc7f3fc3-b0fe-4d3e-a061-76e24e53da1f.png">

## Title page After changes were applied
<img width="242" alt="Screen Shot 2022-11-03 at 9 37 14 AM" src="https://user-images.githubusercontent.com/67210629/199780444-d153499d-05d5-4f8d-9b18-9f30c302b854.png">


## Checklist

- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have searched all existing content and verified my additions are novel
      and unique
- [x] I have verified the change and the rest of the site works as expected

