### PR TITLE
Fix/389 missing hero images

### DIFF
--- a/packages/system/src/globals/global-constants.tsx
+++ b/packages/system/src/globals/global-constants.tsx
@@ -40,7 +40,7 @@ export const FRAMEWORK_RESOURCES = (bigSize = false): LinkCardProps[] => [
 		Icon(props) {
 			return <SolidJSIcon {...props} />
 		},
-		backgroundColor: "#2B4E8B",
+		backgroundColor: "#446b9e",
 		bigSize,
 	},
 	{

--- a/packages/system/src/globals/global-constants.tsx
+++ b/packages/system/src/globals/global-constants.tsx
@@ -3,8 +3,8 @@ import { AngularIcon } from "../icons/angular-icon"
 import { QwikIcon } from "../icons/qwik-icon"
 import { ReactIcon } from "../icons/react-icon"
 import { SolidJSIcon } from "../icons/solidjs-icon"
-import { VueIcon } from "../icons/vue-icon"
 import { SvelteIcon } from "../icons/svelte-icon"
+import { VueIcon } from "../icons/vue-icon"
 
 export const FRAMEWORK_RESOURCES = (bigSize = false): LinkCardProps[] => [
 	{


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change

Fixes the colour scheme of the SolidJS icon background on the landing page's hero section and other frameworks' footer.



## Checklist

<!-- Delete if your change is not a bug fix -->

- [ ] This fix resolves #389

![image](https://user-images.githubusercontent.com/9042219/200338069-ee1250d8-8168-4d8f-9a7e-5aa3f79bcd39.png)

![image](https://user-images.githubusercontent.com/9042219/200338214-105c6f56-0493-4b21-8d71-4b811067ad01.png)
