### PR TITLE
feat: adds graphql content for podcasts

### DIFF
--- a/packages/site/src/data/graphql/podcasts.ts
+++ b/packages/site/src/data/graphql/podcasts.ts
@@ -60,7 +60,7 @@ export const podcasts: Podcast<typeof podcastTags[number]>[] = [
 		image:
 			"https://i1.wp.com/softwareengineeringdaily.com/wp-content/uploads/2022/01/cropped-logo-new.png?fit=296%2C139&ssl=1",
 		hosts: ["SE Daily"],
-		description: "The world through the lens of software",
+		description: "The world through the lens of software.",
 		rss: "https://softwareengineeringdaily.com/feed/podcast/",
 		href: "https://softwareengineeringdaily.com/",
 		tags: ["general"],
@@ -68,7 +68,7 @@ export const podcasts: Podcast<typeof podcastTags[number]>[] = [
 	{
 		title: "JavaScript Jabber",
 		image:
-			"https://topenddevs.nyc3.digitaloceanspaces.com/p83d88m208a3rdbo6qcfjdikc7b5?response-content-disposition=inline%3B%20filename%3D%22javascript_jabber_thumb.jpeg%22%3B%20filename%2A%3DUTF-8%27%27javascript_jabber_thumb.jpeg&response-content-type=image%2Fjpeg&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=STO4LZNRL5TU6SLCP4ZY%2F20221107%2Funused%2Fs3%2Faws4_request&X-Amz-Date=20221107T223130Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c0d01e578c09088b391d2f297790f2108b4ab0773cec147b1e6bbf7c2a09c1bf",
+			"https://encrypted-tbn1.gstatic.com/images?q=tbn:ANd9GcSq5OFUB2C1otCwDgmsaktFo38QpGmBFkLyzQG3jfTdjyt4OSp5",
 		hosts: [
 			"AJ ONeal",
 			"Charles Max Wood",
@@ -99,7 +99,7 @@ export const podcasts: Podcast<typeof podcastTags[number]>[] = [
 			"Matthew Arbesfeld",
 		],
 		description:
-			"PodRocket covers everything you need to know about frontend web development on a weekly basis",
+			"PodRocket covers everything you need to know about frontend web development on a weekly basis.",
 		rss: "https://feeds.fireside.fm/podrocket/rss",
 		href: "https://podrocket.logrocket.com/",
 		tags: ["general"],

--- a/packages/site/src/data/graphql/podcasts.ts
+++ b/packages/site/src/data/graphql/podcasts.ts
@@ -1,5 +1,157 @@
 import { Podcast } from "@framework/system/src/models/podcast"
 
-export const podcastTags = ["general"] as const
+export const podcastTags = ["general", "graphQL", "ruby", "rails"] as const
 
-export const podcasts: Podcast<typeof podcastTags[number]>[] = []
+export const podcasts: Podcast<typeof podcastTags[number]>[] = [
+	{
+		title: "Modern Web",
+		image:
+			"https://pbcdn1.podbean.com/imglogo/image-logo/984467/modern_web_9bpnd.jpg",
+		hosts: ["ThisDot Labs"],
+		description:
+			"Modern Web is a podcast that explores next generation frameworks, standards, and techniques.",
+		rss: "https://www.podbean.com/site/podcatcher/index/blog/7YqKYcoGcvP",
+		href: "https://modernweb.podbean.com/",
+		tags: ["general"],
+	},
+	{
+		title: "Syntax",
+		image: "https://syntax.fm/static/logo.png",
+		hosts: ["Wes Bos", "Scott Tolinski"],
+		description: "A Tasty Treats Podcast for Web Developers.",
+		rss: "https://feed.syntax.fm/rss",
+		href: "https://syntax.fm/",
+		tags: ["general"],
+	},
+	{
+		title: "GraphQLfm",
+		image:
+			"https://panels.twitch.tv/panel-563129908-image-35e79e85-7e57-44bb-9882-21a7c6f1b22e",
+		hosts: ["Marc-Andre Giroux", "Tony Ghita"],
+		description: "Welcome to GraphQL.FM, a Twitch Channel all about GraphQL.",
+		rss: "https://twitchrss.appspot.com/vod/graphqlfm",
+		href: "https://www.twitch.tv/graphqlfm",
+		tags: ["graphQL"],
+	},
+	{
+		title: "GraphQL Radio",
+		image:
+			"https://images.transistor.fm/file/transistor/images/logos/site/10181/medium_darkblue.png",
+		hosts: ["Max Stoiber", "Abhi Aiyer"],
+		description:
+			"Listen in for practical tips from production power users, discussions about the evolution of the language and the tooling, the work of the GraphQL Foundation, and so much more.",
+		rss: "https://feeds.transistor.fm/graphql-radio",
+		href: "https://graphqlradio.com/",
+		tags: ["general", "graphQL"],
+	},
+	{
+		title: "The Changelog",
+		image:
+			"https://cdn.changelog.com/uploads/covers/the-changelog-original.png?v=63725770322",
+		hosts: ["Adam Stacoviak", "Jerod Santo"],
+		description:
+			"Conversations with the hackers, leaders, and innovators of the software world.",
+		rss: "https://changelog.com/podcast/feed",
+		href: "https://changelog.com/",
+		tags: ["general"],
+	},
+	{
+		title: "Software Engineering Daily",
+		image:
+			"https://i1.wp.com/softwareengineeringdaily.com/wp-content/uploads/2022/01/cropped-logo-new.png?fit=296%2C139&ssl=1",
+		hosts: ["SE Daily"],
+		description: "The world through the lens of software",
+		rss: "https://softwareengineeringdaily.com/feed/podcast/",
+		href: "https://softwareengineeringdaily.com/",
+		tags: ["general"],
+	},
+	{
+		title: "JavaScript Jabber",
+		image:
+			"https://topenddevs.nyc3.digitaloceanspaces.com/p83d88m208a3rdbo6qcfjdikc7b5?response-content-disposition=inline%3B%20filename%3D%22javascript_jabber_thumb.jpeg%22%3B%20filename%2A%3DUTF-8%27%27javascript_jabber_thumb.jpeg&response-content-type=image%2Fjpeg&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=STO4LZNRL5TU6SLCP4ZY%2F20221107%2Funused%2Fs3%2Faws4_request&X-Amz-Date=20221107T223130Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c0d01e578c09088b391d2f297790f2108b4ab0773cec147b1e6bbf7c2a09c1bf",
+		hosts: [
+			"AJ ONeal",
+			"Charles Max Wood",
+			"Aimee Knight",
+			"Dan Shappir",
+			"Steve Edwards",
+		],
+		description:
+			"A weekly discussion by top-end JavaScript developers on the technology and skills needed to level up on your JavaScript journey.",
+		rss: "https://topenddevs.com/podcasts/javascript-jabber/rss.rss",
+		href: "https://topenddevs.com/podcasts/javascript-jabber",
+		tags: ["general"],
+	},
+	{
+		title: "PodRocket",
+		image:
+			"https://assets.fireside.fm/file/fireside-images/podcasts/images/3/3911462c-bca2-48c2-9103-610ba304c673/cover_small.jpg?v=3",
+		hosts: [
+			"Ben Edelstein",
+			"Kate Trahan",
+			"Brendan Downing",
+			"Noel Minchow",
+			"Paul Mikulskis",
+			"Kaelan Cooter",
+			"Chris Botaish",
+			"Sean Rayment",
+			"Emily Kochanek Ketner",
+			"Matthew Arbesfeld",
+		],
+		description:
+			"PodRocket covers everything you need to know about frontend web development on a weekly basis",
+		rss: "https://feeds.fireside.fm/podrocket/rss",
+		href: "https://podrocket.logrocket.com/",
+		tags: ["general"],
+	},
+	{
+		title: "Elm Radio",
+		image:
+			"https://is1-ssl.mzstatic.com/image/thumb/Podcasts115/v4/02/39/47/023947f9-9ff7-33cb-7403-a165b4672253/mza_4858302214988168629.jpg/313x0w.webp",
+		hosts: ["Dillon Kearns", "Jeroen Engels"],
+		description: "Tune in to the tools and techniques in the Elm ecosystem.",
+		rss: "https://elm-radio.com/feed.xml",
+		href: "https://elm-radio.com/",
+		tags: ["general"],
+	},
+	{
+		title: "Front End Happy Hour",
+		image:
+			"https://www.frontendhappyhour.com/public/img/front-end-happy-hour.svg?v2",
+		hosts: [
+			"Ryan Burgess",
+			"Jem Young",
+			"Stacy London",
+			"Augustus Yuan",
+			"Mars Jullian",
+			"Shirley Wu",
+		],
+		description:
+			"A software engineering podcast featuring a panel of Software Engineers from Netflix, Twitch, & Atlassian talking over drinks about Frontend, JavaScript, and career development.",
+		rss: "https://feeds.soundcloud.com/users/soundcloud:users:206137365/sounds.rss",
+		href: "https://www.frontendhappyhour.com/",
+		tags: ["general"],
+	},
+	{
+		title: "The Undefined Podcast",
+		image:
+			"https://is1-ssl.mzstatic.com/image/thumb/Podcasts115/v4/b9/1e/7c/b91e7c1a-4c07-73df-4917-8a49aff5cfcc/mza_6445843419933436972.jpg/313x0w.webp",
+		hosts: ["Jared Palmer", "Ken Wheeler"],
+		description:
+			"Full stack developers Jared Palmer and Ken Wheeler have peer-to-peer conversations with world-class engineers about software development.",
+		rss: "https://rss.simplecast.com/podcasts/8781/rss.xml",
+		href: "https://undefined.fm/",
+		tags: ["general"],
+	},
+	{
+		title: "The Bike Shed",
+		image:
+			"https://assets.fireside.fm/file/fireside-images/podcasts/images/1/167c01a1-0eb9-4640-b488-c2f6d6866650/cover_small.jpg?v=6",
+		hosts: ["Joël Quenneville", "Stephanie Minn"],
+		description:
+			"On The Bike Shed, hosts Joël Quenneville and Stephanie Minn discuss development experiences and challenges at thoughtbot with Ruby, Rails, JavaScript, and whatever else is drawing their attention, admiration, or ire this week.",
+		rss: "https://www.bikeshed.fm/rss",
+		href: "https://www.bikeshed.fm/",
+		tags: ["general", "ruby", "rails"],
+	},
+]


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [x] Content addition
- [ ] Bug fix
- [ ] Behavior change

## Summary of change

- [x] Add the Podcasts information in the data files from https://docs.google.com/spreadsheets/d/1KQ-16uyfH8XG1_Xjt4UuG0KvrlH6SrWDx5mKPLihEA8/edit#gid=0
- [x] Test each individual look and external link

### Screenshot

**_Before_**
![image](https://user-images.githubusercontent.com/20880360/200433465-e0dd52d9-a806-474b-8df4-678bf158bdd3.png)


**_After_**
![image](https://user-images.githubusercontent.com/20880360/200433373-75074959-be82-4ab1-b64b-516955b75d16.png)


## Checklist

<!-- Delete if your change is not a content addition -->

- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have searched all existing content and verified my additions are novel
      and unique
- [x] The content was added to the end of the appropriate data list
- [x] All required content fields are accurately populated
- [x] All items are tagged with all relevant tags
- [x] This change resolves #422
- [x] I have confirmed with a maintainer that this change is desired and been
      given the go-ahead to work on it in the relevant issue discussion

