### PR TITLE
fix: undefined for social share cards homepage

### DIFF
--- a/packages/site/src/layouts/base.astro
+++ b/packages/site/src/layouts/base.astro
@@ -25,7 +25,7 @@ const navData = searchData.map(o => pick(o, ["name", "subCategories"]))
 		
 		<meta name="robots" content="noindex">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<SocialMetaTags title={`${currentCategory ? currentCategory : title} | ${import.meta.env.SNOWPACK_PUBLIC_FRAMEWORK}.framework.dev`} siteName={import.meta.env.SNOWPACK_PUBLIC_FRAMEWORK} />
+		<SocialMetaTags title={`${currentCategory ? currentCategory : ''} | ${import.meta.env.SNOWPACK_PUBLIC_FRAMEWORK}.framework.dev`} siteName={import.meta.env.SNOWPACK_PUBLIC_FRAMEWORK} />
 		<meta name="msapplication-TileColor" content="#da532c">
 		<meta name="theme-color" content="#ffffff">
 		<meta charset="UTF-8"/>

--- a/packages/site/src/layouts/base.astro
+++ b/packages/site/src/layouts/base.astro
@@ -25,7 +25,7 @@ const navData = searchData.map(o => pick(o, ["name", "subCategories"]))
 		
 		<meta name="robots" content="noindex">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<SocialMetaTags title={`${currentCategory ? currentCategory : ''} | ${import.meta.env.SNOWPACK_PUBLIC_FRAMEWORK}.framework.dev`} siteName={import.meta.env.SNOWPACK_PUBLIC_FRAMEWORK} />
+		<SocialMetaTags title={`${currentCategory ? currentCategory : 'Featured Resources'} | ${import.meta.env.SNOWPACK_PUBLIC_FRAMEWORK}.framework.dev`} siteName={import.meta.env.SNOWPACK_PUBLIC_FRAMEWORK} />
 		<meta name="msapplication-TileColor" content="#da532c">
 		<meta name="theme-color" content="#ffffff">
 		<meta charset="UTF-8"/>

--- a/packages/site/src/layouts/base.astro
+++ b/packages/site/src/layouts/base.astro
@@ -25,7 +25,7 @@ const navData = searchData.map(o => pick(o, ["name", "subCategories"]))
 		
 		<meta name="robots" content="noindex">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<SocialMetaTags title={`${currentCategory} | ${import.meta.env.SNOWPACK_PUBLIC_FRAMEWORK}.framework.dev`} siteName={import.meta.env.SNOWPACK_PUBLIC_FRAMEWORK} />
+		<SocialMetaTags title={`${currentCategory ? currentCategory : title} | ${import.meta.env.SNOWPACK_PUBLIC_FRAMEWORK}.framework.dev`} siteName={import.meta.env.SNOWPACK_PUBLIC_FRAMEWORK} />
 		<meta name="msapplication-TileColor" content="#da532c">
 		<meta name="theme-color" content="#ffffff">
 		<meta charset="UTF-8"/>


### PR DESCRIPTION
## Type of change

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change
While testing the social share cards, I noticed that the homepage was showing up undefined in the card description. I put in a fix to show the current category if there is one, otherwise show the main title. 

## Before
<img width="754" alt="Screen Shot 2022-11-07 at 3 42 22 PM" src="https://user-images.githubusercontent.com/67210629/200438818-8a12b332-845c-4fbc-ae65-17c33ae643f0.png">

## After
<img width="819" alt="Screen Shot 2022-11-07 at 3 42 38 PM" src="https://user-images.githubusercontent.com/67210629/200438854-4833d7e8-43ec-43ef-8d28-f919a38f5223.png">


I have also tested all of the subpages on [Social Share](https://socialsharepreview.com/) and they are working fine.
closes #419
## Checklist


- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have searched all existing content and verified my additions are novel
      and unique
- [x] I have verified the fix works and introduces no further errors
