### PR TITLE
fix: setting graphql logo to primary color

### DIFF
--- a/packages/system/src/themes/graphql-color-scheme.ts
+++ b/packages/system/src/themes/graphql-color-scheme.ts
@@ -2,7 +2,7 @@ import { ColorPalette } from "./theme-from-palette"
 
 export const graphqlColorPalette: ColorPalette = {
 	highlight: "#E10098",
-	logo: "#e535ab",
+	logo: "#E10098",
 	primary100: "#ffffff",
 	primary99: "#fffbff",
 	primary95: "#ffecf2",


### PR DESCRIPTION
## Type of change

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change
This PR is responsible for changing the logo color in the `graphqlColorPalette` to the primary color listed in the figma files.
closes #432 

Here is the figma file for all of the primary colors for the frameworks
https://www.figma.com/file/3cAQKdlEpCrz7dgeKzJEqQ/Framework-library?node-id=5%3A2

## Checklist

- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have searched all existing content and verified my additions are novel
      and unique