### PR TITLE
fixing site name so it displays GraphQL on homepage and social cards

### DIFF
--- a/packages/site/src/components/social-meta-tags.tsx
+++ b/packages/site/src/components/social-meta-tags.tsx
@@ -11,7 +11,9 @@ export function SocialMetaTags({ siteName, title }: SocialMetaTagsProps) {
 	const description =
 		siteName === "landing"
 			? `Search, compare, and discover top libraries and community-driven resources.`
-			: `Search, compare, and discover top ${titleCasedSiteName} libraries and community-driven resources in ${titleCasedSiteName}.`
+			: `Search, compare, and discover top ${
+					siteName === "graphql" ? "GraphQL" : titleCasedSiteName
+			  } libraries and community-driven resources in ${titleCasedSiteName}.`
 	const url =
 		siteName === "landing"
 			? `https://framework.dev`

--- a/packages/site/src/pages/index.astro
+++ b/packages/site/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-import { formatFieldName } from "@framework/system/src/util/string-utils"
+import { formatFieldName, checkGraphqlName } from "@framework/system/src/util/string-utils"
 import { scrollable } from '@framework/system/src/styles/layouts.css'
 import BaseLayout from '../layouts/base.astro'
 import Homepage from '../components/homepage.tsx'
@@ -42,7 +42,7 @@ const resourceCards = FRAMEWORK_RESOURCES().filter(
 </head>
 <BaseLayout title={`Featured Resources | ${import.meta.env.SNOWPACK_PUBLIC_FRAMEWORK}.framework.dev`} className={scrollable}>
 	<Homepage
-		librariesTitle={`Featured ${formatFieldName(import.meta.env.SNOWPACK_PUBLIC_FRAMEWORK)} Libraries`}
+		librariesTitle={`Featured ${checkGraphqlName(import.meta.env.SNOWPACK_PUBLIC_FRAMEWORK)} Libraries`}
 		libraries={libraries?.data}
 		libraryTags={libraries?.tags}
 		podcasts={podcasts?.data}

--- a/packages/system/src/components/homepage/hero.tsx
+++ b/packages/system/src/components/homepage/hero.tsx
@@ -1,6 +1,6 @@
 import classNames from "classnames"
 import React from "react"
-import { formatFieldName } from "../../util/string-utils"
+import { checkGraphqlName } from "../../util/string-utils"
 import {
 	heroStyle,
 	heroHeadingStyle,
@@ -34,9 +34,9 @@ export function Hero({ className, siteName, ...props }: HeroProps) {
 				/>
 				<Logo className={heroHeadingStyle} siteName={siteName} stretched />
 				<p className={heroParagraphStyle}>
-					Search, compare, and discover top {formatFieldName(siteName)}{" "}
+					Search, compare, and discover top {checkGraphqlName(siteName)}{" "}
 					libraries and community-driven resources in{" "}
-					{formatFieldName(siteName)}.
+					{checkGraphqlName(siteName)}.
 				</p>
 			</div>
 			<div className={heroFeatureHighlightRowStyle}>

--- a/packages/system/src/util/string-utils.ts
+++ b/packages/system/src/util/string-utils.ts
@@ -33,6 +33,10 @@ export function formatFieldValue(inputValue: string) {
 	return titleCased.charAt(0).toUpperCase() + titleCased.slice(1)
 }
 
+export function checkGraphqlName(inputValue: string) {
+	return inputValue === "graphql" ? "GraphQL" : formatFieldValue(inputValue)
+}
+
 export function deserializeFieldName(inputValue: string) {
 	return camelCase(inputValue)
 }


### PR DESCRIPTION
## Type of change

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change
Currently on the homepage site, the name displays Graphql which is incorrect.
I created a function in the `string-utils` file that only capitalizes the first letter for all other frameworks except GraphQL. 
I also changed the name for the social cards.
closes #438 
## Before 

<img width="942" alt="Screen Shot 2022-11-09 at 2 10 47 PM" src="https://user-images.githubusercontent.com/67210629/200952817-6387130a-62cb-4231-ad19-06208fe4f3d3.png">
<img width="316" alt="Screen Shot 2022-11-09 at 2 11 03 PM" src="https://user-images.githubusercontent.com/67210629/200952862-a26dcc0e-d1ab-4b38-849f-2905988337ef.png">
<img width="803" alt="Screen Shot 2022-11-09 at 2 22 30 PM" src="https://user-images.githubusercontent.com/67210629/200954895-4e19d372-8af3-42e7-8ec2-4b86390098c2.png">


## After
<img width="958" alt="Screen Shot 2022-11-09 at 2 11 30 PM" src="https://user-images.githubusercontent.com/67210629/200952961-cf0b738d-9c8b-40b2-b8a8-efea344f0c28.png">
<img width="349" alt="Screen Shot 2022-11-09 at 2 12 38 PM" src="https://user-images.githubusercontent.com/67210629/200953122-1a91ae75-0439-42f6-9580-e9ec361ca396.png">


## Checklist

- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have searched all existing content and verified my additions are novel
      and unique
- [x] I have verified the fix works and introduces no further errors

