### PR TITLE
fix: GraphQL name in social card

### DIFF
--- a/packages/site/src/components/social-meta-tags.tsx
+++ b/packages/site/src/components/social-meta-tags.tsx
@@ -8,12 +8,12 @@ type SocialMetaTagsProps = {
 export function SocialMetaTags({ siteName, title }: SocialMetaTagsProps) {
 	const titleCasedSiteName = titleCase(siteName)
 	const titleCasedTitle = titleCase(title)
+	const showGraphQLName = () =>
+		siteName === "graphql" ? "GraphQL" : titleCasedSiteName
 	const description =
 		siteName === "landing"
 			? `Search, compare, and discover top libraries and community-driven resources.`
-			: `Search, compare, and discover top ${
-					siteName === "graphql" ? "GraphQL" : titleCasedSiteName
-			  } libraries and community-driven resources in ${titleCasedSiteName}.`
+			: `Search, compare, and discover top ${showGraphQLName} libraries and community-driven resources in ${showGraphQLName}.`
 	const url =
 		siteName === "landing"
 			? `https://framework.dev`

--- a/packages/site/src/components/social-meta-tags.tsx
+++ b/packages/site/src/components/social-meta-tags.tsx
@@ -8,12 +8,12 @@ type SocialMetaTagsProps = {
 export function SocialMetaTags({ siteName, title }: SocialMetaTagsProps) {
 	const titleCasedSiteName = titleCase(siteName)
 	const titleCasedTitle = titleCase(title)
-	const showGraphQLName = () =>
+	const formatAllFrameworkTitles = () =>
 		siteName === "graphql" ? "GraphQL" : titleCasedSiteName
 	const description =
 		siteName === "landing"
 			? `Search, compare, and discover top libraries and community-driven resources.`
-			: `Search, compare, and discover top ${showGraphQLName} libraries and community-driven resources in ${showGraphQLName}.`
+			: `Search, compare, and discover top ${formatAllFrameworkTitles} libraries and community-driven resources in ${formatAllFrameworkTitles}.`
 	const url =
 		siteName === "landing"
 			? `https://framework.dev`

--- a/packages/site/src/components/social-meta-tags.tsx
+++ b/packages/site/src/components/social-meta-tags.tsx
@@ -8,8 +8,10 @@ type SocialMetaTagsProps = {
 export function SocialMetaTags({ siteName, title }: SocialMetaTagsProps) {
 	const titleCasedSiteName = titleCase(siteName)
 	const titleCasedTitle = titleCase(title)
-	const formatAllFrameworkTitles = () =>
-		siteName === "graphql" ? "GraphQL" : titleCasedSiteName
+	function formatAllFrameworkTitles() {
+		return siteName === "graphql" ? "GraphQL" : titleCasedSiteName
+	}
+
 	const description =
 		siteName === "landing"
 			? `Search, compare, and discover top libraries and community-driven resources.`

--- a/packages/site/src/components/social-meta-tags.tsx
+++ b/packages/site/src/components/social-meta-tags.tsx
@@ -13,7 +13,7 @@ export function SocialMetaTags({ siteName, title }: SocialMetaTagsProps) {
 	const description =
 		siteName === "landing"
 			? `Search, compare, and discover top libraries and community-driven resources.`
-			: `Search, compare, and discover top ${formatAllFrameworkTitles} libraries and community-driven resources in ${formatAllFrameworkTitles}.`
+			: `Search, compare, and discover top ${formatAllFrameworkTitles()} libraries and community-driven resources in ${formatAllFrameworkTitles()}.`
 	const url =
 		siteName === "landing"
 			? `https://framework.dev`


### PR DESCRIPTION
## Type of change

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change
This PR fixes the incorrect spelling for GraphQL in the social cards. 
closes #455 

## Image of the current issue
<img width="816" alt="Screen Shot 2022-11-09 at 3 43 27 PM" src="https://user-images.githubusercontent.com/67210629/200965833-6a439bdb-b61d-4021-b6b2-4c14d2e7af1b.png">

## Checklist

- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have searched all existing content and verified my additions are novel
      and unique
- [x] I have verified the change and the rest of the site works as expected
