### PR TITLE
fix: view all books href

### DIFF
--- a/packages/system/src/components/homepage/books.tsx
+++ b/packages/system/src/components/homepage/books.tsx
@@ -15,7 +15,7 @@ export function Books({ className, books, ...props }: BooksProps) {
 		<FeatureAndList
 			className={classNames(className, booksStyle)}
 			title="Top-tier books to read"
-			viewAll={{ title: "View all books", href: "/categories/courses" }}
+			viewAll={{ title: "View all books", href: "/categories/books" }}
 			items={randomBooks.map((book) => {
 				return {
 					image: { src: book.image, style: "book" },


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change

View all books now properly directs to books

<!-- Provide a brief summary of what changes this PR includes, like "added some popular React podcasts" or "fixed navigation menu getting cut off on screens narrower than 320px" -->

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->



<!-- Delete if your change is not a bug fix -->

- [x] This fix resolves #451 
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors


