### PR TITLE
refactor: makes the libary nav dynamic

### DIFF
--- a/packages/site/src/data/search-data.ts
+++ b/packages/site/src/data/search-data.ts
@@ -26,15 +26,7 @@ export async function getSearchData(
 			indexMetadata: libraryIndexMetadata,
 			name: libraryIndexMetadata.name,
 			tags: libraryTags,
-			subCategories: [
-				"state management",
-				"data fetching",
-				"styling",
-				"component library",
-				"forms",
-				"framework",
-				"internationalization",
-			] as typeof libraryTags[number][],
+			subCategories: libraryTags as typeof libraryTags[number][],
 		},
 		{
 			data: tools,


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Content addition
- [ ] Bug fix
- [x] Behavior change

## Summary of change

Make the `Libraries` nav items to be dynamic to the tags

### Screenshot

**_Before_**
![Image](https://user-images.githubusercontent.com/20880360/201183201-09fbd7ed-0b5c-4e6a-abb6-0e695439bd68.png)

**_After_**
![image](https://user-images.githubusercontent.com/20880360/201203153-1da0944e-4628-4fa4-8661-27cb18f2e270.png)



<!-- Provide a brief summary of what changes this PR includes, like "added some popular React podcasts" or "fixed navigation menu getting cut off on screens narrower than 320px" -->

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->



<!-- Delete if your change is not a behaviour change -->

- [x] This change resolves #461 
- [x] I have confirmed with a maintainer that this change is desired and been
      given the go-ahead to work on it in the relevant issue discussion
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the change and the rest of the site works as expected

