### PR TITLE
fix(#368): add support for dark background on transparent images

### DIFF
--- a/packages/site/src/data/angular/communities.ts
+++ b/packages/site/src/data/angular/communities.ts
@@ -226,6 +226,7 @@ export const communities: Community<typeof communityTags[number]>[] = [
 		image: "https://jsgamedev.com/img/logo.svg",
 		type: "Live Events",
 		href: "https://jsgamedev.com/",
+		darkImageBackground: true,
 		tags: ["conferences"],
 	},
 	{

--- a/packages/site/src/data/react/communities.ts
+++ b/packages/site/src/data/react/communities.ts
@@ -245,6 +245,7 @@ export const communities: Community<typeof communityTags[number]>[] = [
 		image: "https://jsgamedev.com/img/logo.svg",
 		type: "Live Events",
 		href: "https://jsgamedev.com/",
+		darkImageBackground: true,
 		tags: ["conferences"],
 	},
 	{

--- a/packages/site/src/data/vue/communities.ts
+++ b/packages/site/src/data/vue/communities.ts
@@ -247,6 +247,7 @@ export const communities: Community<typeof communityTags[number]>[] = [
 		image: "https://jsgamedev.com/img/logo.svg",
 		type: "Live Events",
 		href: "https://jsgamedev.com/",
+		darkImageBackground: true,
 		tags: ["conferences"],
 	},
 	{

--- a/packages/system/src/components/cards/community-card.tsx
+++ b/packages/system/src/components/cards/community-card.tsx
@@ -22,6 +22,7 @@ export function CommunityCard({ community, ...props }: CommunityCardProps) {
 			title={community.name}
 			subtitle={community.type}
 			href={community.href}
+			darkImageBackground={community.darkImageBackground}
 			tags={community.tags}
 			layout="imageFirst"
 			image={community.image}

--- a/packages/system/src/components/cards/resource-card.tsx
+++ b/packages/system/src/components/cards/resource-card.tsx
@@ -8,7 +8,6 @@ import { CardSelector } from "./card-selector"
 import { DiscreteAttribute } from "../discrete-attribute"
 import { InfoPopup } from "../info-popup"
 import {
-	bookImageContainerStyle,
 	resourceCardBodyStyle,
 	resourceCardBookImageDecoration,
 	resourceCardFooterStyle,
@@ -81,7 +80,6 @@ export function ResourceCard({
 				<div
 					className={classNames(
 						resourceCardImageContainerStyle,
-						imageLayout === "book" && bookImageContainerStyle,
 						{
 							darkBackground: darkImageBackground,
 						}

--- a/packages/system/src/models/community.ts
+++ b/packages/system/src/models/community.ts
@@ -15,6 +15,8 @@ export interface Community<T extends string> extends SearchableRecord<T> {
 	type: string
 	/** A link to the community's website */
 	href: string
+ 	/** Option to add a dark color to the background of the image */
+	darkImageBackground?: boolean
 }
 
 export const communityIndexMetadata = {


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change

Currently images with a transparent background that require a dark background are illegible. This PR provides a solution to address this issue (and future transparent images) by adding `darkImageBackground` with a boolean value to community resources that require it.

Before:
<img width="273" alt="Screen Shot 2022-11-17 at 5 49 51 PM" src="https://user-images.githubusercontent.com/90362911/202615202-40b6ecdf-42c6-4008-96dd-cb3eecd7ef49.png">

After:
<img width="279" alt="Screen Shot 2022-11-17 at 5 49 01 PM" src="https://user-images.githubusercontent.com/90362911/202615227-f13dd46b-cfd1-42d6-9d2d-bae8bfb635ff.png">


## Checklist

<!-- Delete if your change is not a bug fix -->

- [x] This fix resolves #368 
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors

closes #368 
