### PR TITLE
fix: broken GraphQL podcast image

### DIFF
--- a/packages/site/src/data/graphql/podcasts.ts
+++ b/packages/site/src/data/graphql/podcasts.ts
@@ -57,7 +57,7 @@ export const podcasts: Podcast<typeof podcastTags[number]>[] = [
 	{
 		title: "Software Engineering Daily",
 		image:
-			"https://scontent-sjc3-1.xx.fbcdn.net/v/t39.30808-6/272759018_1675033572828553_5594405914840993192_n.jpg?_nc_cat=110&ccb=1-7&_nc_sid=09cbfe&_nc_ohc=XjCKm-Hd8V0AX8YjMH3&_nc_ht=scontent-sjc3-1.xx&oh=00_AfAQ2zydkAy9gH92BIod9CTKaB0Avc-d5zGxAfZtkyaEFQ&oe=637120B2",
+			"https://is1-ssl.mzstatic.com/image/thumb/Podcasts125/v4/0e/19/12/0e1912de-b06c-f84e-b9b8-a72906fb88b0/mza_5580768301150732540.png/626x0w.webp",
 		hosts: ["SE Daily"],
 		description: "The world through the lens of software.",
 		rss: "https://softwareengineeringdaily.com/feed/podcast/",


### PR DESCRIPTION
## Type of change

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change

Replacing broken image for podcast

## Before
<img width="598" alt="Screen Shot 2022-11-21 at 3 18 54 PM" src="https://user-images.githubusercontent.com/67210629/203177362-f66bc33f-3ec8-494a-8260-d520e9cbda81.png">


## After

<img width="589" alt="Screen Shot 2022-11-21 at 3 17 40 PM" src="https://user-images.githubusercontent.com/67210629/203177202-3959b3e7-db6f-4d69-8851-dcaebfc5f5aa.png">

## Checklist

- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)

