### PR TITLE
fix(#364): add missing chakra ui logo

### DIFF
--- a/packages/site/src/data/vue/libraries.ts
+++ b/packages/site/src/data/vue/libraries.ts
@@ -206,7 +206,7 @@ export const libraries: Library<typeof libraryTags[number]>[] = [
 		href: "https://vue.chakra-ui.com/",
 		description:
 			"Chakra UI gives you a set of accessible and composable Vue components that you can use to build your favourite applications and sites. Made for Vue 2.X",
-		image: "",
+		image: "https://raw.githubusercontent.com/chakra-ui/chakra-ui/9e3d91fd73b1cadc14f98b6c834c0e6faf134bd2/media/logomark-colored.svg",
 		tags: ["component library", "Vue 2"],
 		language: libraryTags[0],
 	},


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change

Chakra UI logo is missing from the Vue framework.dev page. PR provides current logo from Chakra UI GitHub.

<img width="259" alt="Screen Shot 2022-11-22 at 3 10 25 PM" src="https://user-images.githubusercontent.com/90362911/203451505-91a9c802-79f2-44bb-ac8d-a461506cf1bb.png">


## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

<!-- Delete if your change is not a bug fix -->

- [x] This fix resolves #364 
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors
