### PR TITLE
chore(#252): update reach dialog and config due to cli errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
 		"@babel/core": "^7.15.8",
 		"@reach/auto-id": "^0.16.0",
 		"@reach/combobox": "^0.16.3",
-		"@reach/dialog": "^0.16.2",
+		"@reach/dialog": "^0.18.0",
 		"@reach/portal": "^0.16.2",
 		"@reach/tooltip": "^0.16.2",
 		"assert-never": "^1.2.1",

--- a/packages/site/snowpack.config.js
+++ b/packages/site/snowpack.config.js
@@ -24,7 +24,16 @@ module.exports = {
 			"@reach/utils/use-stateful-ref-value",
 			"@reach/tooltip",
 			"@reach/utils/get-document-dimensions",
-		],
+			"@reach/utils/owner-document",
+			"@reach/utils/use-force-update",
+			"@reach/utils/use-isomorphic-layout-effect",
+			"@reach/utils/type-check",
+			"@reach/utils/noop",
+			"@reach/utils/dev-utils",
+			"@reach/utils/compose-refs",
+			"@reach/utils/compose-event-handlers",
+			"@reach/portal"
+			],
 		env: {
 			NODE_ENV: true,
 		},


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Content addition
- [ ] Bug fix
- [ ] Behavior change

## Summary of change

Cleared the "DialogContent" error from the CLI by updating `@reach/dialog` and updating `snowpack.config.js`. The `innerHTML` error is generated from build in Snowpack and should be resolved once we migrate to Vite.

Before:
<img src="https://user-images.githubusercontent.com/90362911/203455684-c8f96fdf-20b2-4f5d-b725-b512de5333c7.png">
----------
After:
<img width="795" alt="Screen Shot 2022-11-29 at 10 35 53 AM" src="https://user-images.githubusercontent.com/90362911/204642218-a1c019de-0fb7-4dfb-960f-3b1e47ee7988.png">


## Checklist

<!-- Delete if your change is not a bug fix -->

- [x] This fix resolves #252 
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors