### PR TITLE
New styles for links to non-NPM packages

### DIFF
--- a/packages/system/src/components/cards/library-card.css.ts
+++ b/packages/system/src/components/cards/library-card.css.ts
@@ -1,6 +1,40 @@
 import { style } from '@vanilla-extract/css'
+import { sprinkles } from '../../sprinkles/sprinkles.css'
+import { vars } from '../../themes/themes.css'
 
 export const libraryCardBadgeStyle = style({
 	height: 20,
 	maxWidth: '100%',
 })
+
+export const libraryPackageLinkStyle = style([
+	sprinkles({
+		backgroundColor: 'background',
+		border: 'light',
+		paddingY: 4,
+		paddingX: 8,
+		borderRadius: 6,
+		textStyle: 'buttonSmall',
+	}),
+	{
+		cursor: 'pointer',
+		transition: 'background 0.15s ease-in',
+		selectors: {
+			'&:hover, &:focus': {
+				backgroundColor: vars.palette.neutral90,
+				transition: 'none',
+			},
+		},
+	},
+])
+
+export const libraryPackageTextStyle = style([
+	{
+		opacity: 0.6,
+		transition: 'opacity 0.15s ease-in',
+		':hover': {
+			opacity: 0.75,
+			transition: 'none',
+		},
+	},
+])

--- a/packages/system/src/components/cards/library-card.css.ts
+++ b/packages/system/src/components/cards/library-card.css.ts
@@ -9,19 +9,16 @@ export const libraryCardBadgeStyle = style({
 
 export const libraryPackageLinkStyle = style([
 	sprinkles({
-		backgroundColor: 'background',
-		border: 'light',
-		paddingY: 4,
-		paddingX: 8,
-		borderRadius: 6,
+		borderRadius: 4,
 		textStyle: 'buttonSmall',
 	}),
 	{
+		backgroundColor: vars.palette.neutral30,
 		cursor: 'pointer',
 		transition: 'background 0.15s ease-in',
 		selectors: {
 			'&:hover, &:focus': {
-				backgroundColor: vars.palette.neutral90,
+				backgroundColor: vars.palette.neutral40,
 				transition: 'none',
 			},
 		},
@@ -29,11 +26,15 @@ export const libraryPackageLinkStyle = style([
 ])
 
 export const libraryPackageTextStyle = style([
+	sprinkles({
+		display: 'block',
+		marginY: 4,
+		marginX: 8,
+	}),
 	{
-		opacity: 0.6,
+		color: vars.palette.neutral95,
 		transition: 'opacity 0.15s ease-in',
 		':hover': {
-			opacity: 0.75,
 			transition: 'none',
 		},
 	},

--- a/packages/system/src/components/cards/library-card.tsx
+++ b/packages/system/src/components/cards/library-card.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import { Library } from '../../models/library'
 import {
 	libraryCardBadgeStyle,
@@ -76,9 +77,14 @@ export function LibraryCard({ library, ...props }: LibraryCardProps) {
 						</>
 					) : library?.package !== '' ? (
 						// TODO: Have other frameworks decide what image to use if not npm
-						<div className={libraryPackageLinkStyle}>
+						<div
+							className={classNames(
+								libraryPackageLinkStyle,
+								libraryCardBadgeStyle
+							)}
+						>
 							<a className={libraryPackageTextStyle} href={library.package}>
-								Package
+								📦 Package
 							</a>
 						</div>
 					) : null}

--- a/packages/system/src/components/cards/library-card.tsx
+++ b/packages/system/src/components/cards/library-card.tsx
@@ -1,5 +1,9 @@
 import { Library } from '../../models/library'
-import { libraryCardBadgeStyle } from './library-card.css'
+import {
+	libraryCardBadgeStyle,
+	libraryPackageLinkStyle,
+	libraryPackageTextStyle,
+} from './library-card.css'
 import {
 	getBundleSizeBadge,
 	getGitHubStarsBadge,
@@ -72,11 +76,11 @@ export function LibraryCard({ library, ...props }: LibraryCardProps) {
 						</>
 					) : library?.package !== '' ? (
 						// TODO: Have other frameworks decide what image to use if not npm
-						<Badge
-							data={''}
-							href={library.package}
-							label={`${library.name} Package`}
-						/>
+						<div className={libraryPackageLinkStyle}>
+							<a className={libraryPackageTextStyle} href={library.package}>
+								Package
+							</a>
+						</div>
 					) : null}
 				</>
 			}

--- a/packages/system/src/components/cards/resource-card.css.ts
+++ b/packages/system/src/components/cards/resource-card.css.ts
@@ -157,3 +157,15 @@ export const resourceCardFooterStyle = style([
 		gridArea: 'footer',
 	},
 ])
+
+export const resourceCardFooterItemsRowStyle = style([
+	sprinkles({
+		layout: 'row',
+		gap: 4,
+		paddingBottom: 12,
+		flexWrap: 'wrap',
+	}),
+	{
+		alignItems: 'flex-start',
+	},
+])

--- a/packages/system/src/components/cards/resource-card.tsx
+++ b/packages/system/src/components/cards/resource-card.tsx
@@ -18,6 +18,7 @@ import {
 	resourceCardSubtitleStyle,
 	resourceCardTitleContainerStyle,
 	resourceCardTitleStyle,
+	resourceCardFooterItemsRowStyle,
 } from './resource-card.css'
 import { Tag } from '../tag'
 import { useId } from '@reach/auto-id'
@@ -130,12 +131,7 @@ export function ResourceCard({
 					<>
 						<div
 							className={classNames(
-								sprinkles({
-									layout: 'row',
-									gap: 4,
-									paddingBottom: 12,
-									flexWrap: 'wrap',
-								}),
+								resourceCardFooterItemsRowStyle,
 								'hide-in-percy'
 							)}
 						>

--- a/packages/system/src/util/example-content.ts
+++ b/packages/system/src/util/example-content.ts
@@ -70,7 +70,7 @@ export const exampleLibraries: Library[] = [
 		name: 'Flux',
 		author: 'Facebook',
 		repo: 'https://www.github.com/facebook/flux',
-		package: 'https://www.npmjs.com/package/flux',
+		package: 'https://www.example.com/package/flux',
 		href: 'https://facebook.github.io/flux/',
 		description:
 			'The original state management architecture for React utilizing a unidirectional data flow. Now deprecated and in maintenance mode.',


### PR DESCRIPTION
## Type of change

- [ ] Content addition
- [X] Bug fix
- [X] Behavior change

## Summary of change

Where a package isn't hosted on NPM, the existing fallback is an unstyled link. It doesn't fit with the styles of any of the other badges in library cards and its purpose is visually confusing. This PR implements a new fallback with styles that better match existing badges.

![image](https://user-images.githubusercontent.com/2487968/205417376-6e5309df-311a-433b-9f29-cb558f700a23.png)

## Checklist

- [X] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [X] I have verified the fix works and introduces no further errors
- [X] I have confirmed with a maintainer that this change is desired and been
      given the go-ahead to work on it in the relevant issue discussion
- [X] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [X] I have verified the change and the rest of the site works as expected
- [X] If the change introduces new components, these have been added to
      `packages/system/src/components` with a `.stories.tsx` file that
      adequately renders possible variations of each component.
