### PR TITLE
fixing spelling error in banner component

### DIFF
--- a/packages/system/src/components/homepage/contributor-banner.tsx
+++ b/packages/system/src/components/homepage/contributor-banner.tsx
@@ -31,7 +31,7 @@ export function ContributorBanner({
 				</h1>
 				<p className={sprinkles({ textStyle: "bodyLong2" })}>
 					Create a PR if you see mistakes, room for improvement, or new
-					opportunties to help the dev team.
+					opportunities to help the dev team.
 				</p>
 			</div>
 			<div className={sprinkles({ layout: "row" })}>


### PR DESCRIPTION
## Type of change

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change
I fixed the spelling error that was in the banner component. This banner component is used in all framework.dev sites. 

closes #529 

## Checklist

- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have searched all existing content and verified my additions are novel
      and unique
- [x] The content was added to the end of the appropriate data list


