### PR TITLE
Remove GraphQL Tools From Qwik Tools

### DIFF
--- a/packages/site/src/data/qwik/tools.ts
+++ b/packages/site/src/data/qwik/tools.ts
@@ -18,24 +18,6 @@ export const tools: Tool<typeof toolTags[number]>[] = [
 		tags: ["development"],
 	},
 	{
-		name: "GraphQL Playground for Chrome",
-		author: "Dustin R. Callaway",
-		description: "Chrome extension for GraphQL Playground",
-		image:
-			"https://upload.wikimedia.org/wikipedia/commons/1/17/GraphQL_Logo.svg",
-		href: "https://chrome.google.com/webstore/detail/graphql-playground-for-ch/kjhjcgclphafojaeeickcokfbhlegecd?hl=en",
-		tags: ["Chrome"],
-	},
-	{
-		name: "GraphQL Playground for Firefox",
-		author: "Francesco De Stefano",
-		description: "Firefox extension for GraphQL Playground",
-		image:
-			"https://upload.wikimedia.org/wikipedia/commons/1/17/GraphQL_Logo.svg",
-		href: "https://addons.mozilla.org/en-US/firefox/addon/graphql-developer-tools/",
-		tags: ["Firefox"],
-	},
-	{
 		name: "TanStack Router",
 		author: "Tanner Linsley",
 		description: "A fully typesafe router with first-class search-param APIs and built-in caching, built for JS/TS",


### PR DESCRIPTION
Close: https://github.com/thisdot/framework.dev/issues/546

## Type of change

<!-- Add an x to the categories that apply -->

- [x] Content addition
- [ ] Bug fix
- [ ] Behavior change

## Summary of change

Removed graphql tools in the qwik tools that don't make below

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

<!-- Delete if your change is not a content addition -->

- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have searched all existing content and verified my additions are novel
      and unique
- [x] The content was added to the end of the appropriate data list
- [x] All required content fields are accurately populated
- [x] All items are tagged with all relevant tags
