### PR TITLE
Disable selection for Deno

### DIFF
--- a/packages/system/src/components/cards/library-card.tsx
+++ b/packages/system/src/components/cards/library-card.tsx
@@ -31,6 +31,7 @@ export function LibraryCard({ library, ...props }: LibraryCardProps) {
 			darkImageBackground={library.darkImageBackground}
 			href={library.href}
 			tags={library.tags}
+			allowSelection={!!library.package}
 			badges={
 				<>
 					{library?.repo.includes("github.com") ? (

--- a/packages/system/src/components/cards/resource-card.tsx
+++ b/packages/system/src/components/cards/resource-card.tsx
@@ -40,6 +40,7 @@ export interface ResourceCardProps
 	href: string
 	tags: string[]
 	selected?: boolean
+	allowSelection?: boolean
 	onSelect?: (selected: boolean) => void
 	onTagClick: (tag: string) => void
 }
@@ -58,6 +59,7 @@ export function ResourceCard({
 	tags,
 	attributes = [],
 	selected = false,
+	allowSelection = true,
 	onSelect,
 	badges,
 	onTagClick,
@@ -78,12 +80,9 @@ export function ResourceCard({
 		>
 			{image && (
 				<div
-					className={classNames(
-						resourceCardImageContainerStyle,
-						{
-							darkBackground: darkImageBackground,
-						}
-					)}
+					className={classNames(resourceCardImageContainerStyle, {
+						darkBackground: darkImageBackground,
+					})}
 				>
 					{imageLayout === "book" && layout === "imageFirst" ? (
 						<BookImageDecoration>
@@ -103,7 +102,7 @@ export function ResourceCard({
 					</a>
 					<p className={resourceCardSubtitleStyle}>{subtitle}</p>
 				</div>
-				{onSelect && (
+				{allowSelection && onSelect && (
 					<CardSelector
 						checked={selected}
 						onChange={(e) => {


### PR DESCRIPTION
## Type of change

- [ ] Content addition
- [ ] Bug fix
- [x] Behavior change

## Summary of change

Deno does not have a centralized repository of packages. There are some hosting services, like deno.land/x, but they don't expose package stats easily, developers are not required to use this hosting service. They can fetch modules from anywhere, even directly from GitHub.

Therefore we've decided to disable the comparison feature for Deno:

<img width="1454" alt="CleanShot 2022-12-09 at 11 01 13@2x" src="https://user-images.githubusercontent.com/5459296/206676809-239358ee-3b36-4c25-b148-a73dcf13dbe5.png">

## Checklist

- [x] I have confirmed with a maintainer that this change is desired and been
      given the go-ahead to work on it in the relevant issue discussion
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the change and the rest of the site works as expected
- [x] If the change introduces new components, these have been added to
      `packages/system/src/components` with a `.stories.tsx` file that
      adequately renders possible variations of each component.
