### PR TITLE
Fix comparison table not showing full npm stats

### DIFF
--- a/packages/system/src/components/comparison-table/index.tsx
+++ b/packages/system/src/components/comparison-table/index.tsx
@@ -55,7 +55,17 @@ export function ComparisonTable({
 					"Content-Type": "application/json",
 					Accept: "application/json",
 				},
-				body: JSON.stringify(libraries.map((library) => library.package)),
+				body: JSON.stringify(
+					libraries.map((library) => {
+						if (library.package.includes("npmjs.com")) {
+							return library.package.replace(
+								/(?:http(?:s)?:\/\/(?:www\.)?)npmjs\.com\/package\//,
+								""
+							)
+						}
+						return library.package
+					})
+				),
 				signal: abortController.signal,
 			})
 				.then((res) => res.json())


### PR DESCRIPTION
## Type of change

- [ ] Content addition
- [X] Bug fix
- [ ] Behavior change

## Summary of change

The npms.io API to fetch comparison table stats expects the package name, not the full NPM URL. This fix checks if the library package value contains the URL, and strips it out if it does.

## Checklist

- [X] This fix resolves #539
- [X] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [X] I have verified the fix works and introduces no further errors