### PR TITLE
feat: 574 contributors banner improvements

### DIFF
--- a/packages/landing-site/src/components/contributor-banner.tsx
+++ b/packages/landing-site/src/components/contributor-banner.tsx
@@ -1,10 +1,18 @@
 import { ContributorBanner as _ContributorBanner } from "@framework/system/src/components/homepage/contributor-banner"
 import { ContributorData } from "@framework/system/src/components/homepage/contributor"
+import { sprinkles } from "@framework/system/src/sprinkles/sprinkles.css"
 
 export default function ContributorBanner({
 	contributors,
 }: {
 	contributors: ContributorData[]
 }) {
-	return <_ContributorBanner contributors={contributors} />
+	return (
+		<_ContributorBanner
+			contributors={contributors}
+			className={sprinkles({
+				marginTop: { mobile: 56, desktop: 152 },
+			})}
+		/>
+	)
 }

--- a/packages/landing-site/src/components/contributor-banner.tsx
+++ b/packages/landing-site/src/components/contributor-banner.tsx
@@ -1,7 +1,10 @@
-import {ContributorBanner as _ContributorBanner} from '@framework/system/src/components/homepage/contributor-banner'
-import {ContributorData} from '@framework/system/src/components/homepage/contributor'
+import { ContributorBanner as _ContributorBanner } from "@framework/system/src/components/homepage/contributor-banner"
+import { ContributorData } from "@framework/system/src/components/homepage/contributor"
 
-
-export default function ContributorBanner({contributors}:{contributors: ContributorData[]}) {
-    return (<_ContributorBanner contributors={contributors}/>)
+export default function ContributorBanner({
+	contributors,
+}: {
+	contributors: ContributorData[]
+}) {
+	return <_ContributorBanner contributors={contributors} />
 }

--- a/packages/landing-site/src/components/contributor-banner.tsx
+++ b/packages/landing-site/src/components/contributor-banner.tsx
@@ -1,0 +1,7 @@
+import {ContributorBanner as _ContributorBanner} from '@framework/system/src/components/homepage/contributor-banner'
+import {ContributorData} from '@framework/system/src/components/homepage/contributor'
+
+
+export default function ContributorBanner({contributors}:{contributors: ContributorData[]}) {
+    return (<_ContributorBanner contributors={contributors}/>)
+}

--- a/packages/landing-site/src/components/resources-info-banner.tsx
+++ b/packages/landing-site/src/components/resources-info-banner.tsx
@@ -9,7 +9,7 @@ export default function ResourcesInfoBanner() {
 			description="Select one of the frameworks below to begin exploring framework.dev!"
 			resourceCards={FRAMEWORK_RESOURCES()}
 			className={sprinkles({
-				marginTop: { mobile: 56, desktop: 152 },
+				marginTop: { mobile: 32, desktop: 64 },
 			})}
 		/>
 	)

--- a/packages/landing-site/src/layouts/base.astro
+++ b/packages/landing-site/src/layouts/base.astro
@@ -1,6 +1,8 @@
 ---
 import { fontHeadTags } from '@framework/system/src/globals/font-import.mjs'
+import { getContributorsData } from '@framework/system/src/github-util/get-contributors'
 import ResourcesInfoBanner from '../components/resources-info-banner'
+import ContributorBanner from '../components/contributor-banner'
 import Hero from '../components/hero'
 import PitchCards from '../components/pitch-cards'
 import Footer from '../components/footer';
@@ -10,6 +12,8 @@ import { landingBody } from '@framework/system/src/styles/layouts.css'
 import { SocialMetaTags } from '../../../site/src/components/social-meta-tags';
 
 const { title } = Astro.props
+
+const contributorsData = await getContributorsData()
 ---
 <!DOCTYPE html>
 <html class={landingTheme} lang="en">
@@ -47,6 +51,7 @@ const { title } = Astro.props
 		<Hero />
 		<section class={landingBody}>
 			<PitchCards />
+			<ContributorBanner contributors={contributorsData}/>
 			<ResourcesInfoBanner />
 			<Footer />
 		</section>

--- a/packages/site/src/pages/index.astro
+++ b/packages/site/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import { formatFieldName, formatAllFrameworkTitles } from "@framework/system/src/util/string-utils"
+import { getContributorsData } from '@framework/system/src/github-util/get-contributors'
 import { scrollable } from '@framework/system/src/styles/layouts.css'
 import BaseLayout from '../layouts/base.astro'
 import Homepage from '../components/homepage.tsx'
@@ -15,16 +16,7 @@ const books = searchData.find(category => category.name === "books")
 const tools = searchData.find(category => category.name === "tools")
 const communities = searchData.find(category => category.name === "communities")
 
-interface ContributorAvatars {
-	avatar_url: string
-}
-
-const data =
-		await fetch(
-			"https://api.github.com/repos/thisdot/framework.dev/contributors?anon=1"
-		)
-			.then((res) => res.json())
-			.then((data: ContributorAvatars[]) => data.map((user) => user.avatar_url))
+const contributorsData = await getContributorsData()
 		
 const searchableWebsiteStructuredData = {
 	"@context": "https://schema.org",
@@ -64,6 +56,6 @@ const resourceCards = FRAMEWORK_RESOURCES().filter(
 		communities={communities?.data}
 		siteName={import.meta.env.SNOWPACK_PUBLIC_FRAMEWORK}
 		resourceCards={resourceCards}
-		contributorsData = {data}
+		contributorsData = {contributorsData}
 	/>
 </BaseLayout>

--- a/packages/system/src/components/homepage/contributor-banner.css.ts
+++ b/packages/system/src/components/homepage/contributor-banner.css.ts
@@ -4,7 +4,6 @@ import { pxToRem } from "../../util/style-utils"
 
 export const contributorBannerStyle = style([
 	sprinkles({
-		backgroundColor: "secondaryContainer",
 		padding: { mobile: 32, tablet: 56 },
 		borderRadius: 12,
 		gap: { mobile: 32, tablet: 16 },
@@ -13,21 +12,24 @@ export const contributorBannerStyle = style([
 			tablet: "grid",
 		},
 		flexDirection: "column",
-		alignItems: "center",
+		alignItems: "start",
 	}),
 	{
+		backgroundColor: "transparent",
 		gridTemplateColumns: "1fr 3fr min-content",
 	},
 ])
 
-export const contributorImageStyle = style([
-	sprinkles({ borderColor: "onSecondaryContainer" }),
+const contributorsSpacingPx = 4
+export const contributorsContainerStyle = style([
 	{
-		maxWidth: pxToRem(72),
-		borderRadius: "50%",
-		borderWidth: pxToRem(4),
-		borderStyle: "solid",
-		marginLeft: pxToRem(5),
+		margin: pxToRem(-contributorsSpacingPx / 2),
+	},
+])
+
+export const contributorElementStyle = style([
+	{
+		margin: pxToRem(contributorsSpacingPx / 2),
 	},
 ])
 

--- a/packages/system/src/components/homepage/contributor-banner.stories.tsx
+++ b/packages/system/src/components/homepage/contributor-banner.stories.tsx
@@ -8,10 +8,27 @@ export default {
 	title: "Home/Contributor Banner",
 	component: ContributorBannerComponent,
 	args: {
-		contributorImages: [
-			"https://github.com/jbachhardie.png",
-			"https://github.com/tvanantwerp.png",
-			"https://github.com/markshenouda.png",
+		contributors: [
+			{
+				login: "jbachhardie",
+				url: "https://github.com/jbachhardie",
+				avatarUrl: "https://github.com/jbachhardie.png",
+			},
+			{
+				login: "tvanantwerp",
+				url: "https://github.com/tvanantwerp",
+				avatarUrl: "https://github.com/tvanantwerp.png",
+			},
+			{
+				login: "markshenouda",
+				url: "https://github.com/markshenouda",
+				avatarUrl: "https://github.com/markshenouda.png",
+			},
+			{
+				login: "ktrz",
+				url: "https://github.com/ktrz",
+				avatarUrl: "https://github.com/ktrz.png",
+			},
 		],
 	},
 } as Meta

--- a/packages/system/src/components/homepage/contributor-banner.tsx
+++ b/packages/system/src/components/homepage/contributor-banner.tsx
@@ -2,21 +2,23 @@ import classNames from "classnames"
 import React from "react"
 import { sprinkles } from "../../sprinkles/sprinkles.css"
 import { Button } from "../button"
+import { Contributor, ContributorData } from "./contributor"
 import {
 	contributorBannerStyle,
-	contributorImageStyle,
 	buttonStyles,
+	contributorsContainerStyle,
+	contributorElementStyle,
 } from "./contributor-banner.css"
 
 export interface ContributorBannerProps
 	extends React.ComponentPropsWithoutRef<"div"> {
-	contributorImages: string[]
+	contributors: ContributorData[]
 }
 
 export function ContributorBanner({
 	children,
 	className,
-	contributorImages,
+	contributors,
 	...props
 }: ContributorBannerProps) {
 	return (
@@ -31,8 +33,9 @@ export function ContributorBanner({
 					Build better. Together.
 				</h1>
 				<p className={sprinkles({ textStyle: "bodyLong2" })}>
-					Create a PR if you see mistakes, room for improvement, or new
-					opportunities to help the dev team.
+					Know a resource that should be included? Spotted a typo or mistake?
+					We&apos;d love to have your contributions! Please send us a pull
+					request and get added to our growing collection of contributors.
 				</p>
 				<Button
 					className={classNames(className, buttonStyles)}
@@ -43,13 +46,12 @@ export function ContributorBanner({
 					Contribute
 				</Button>
 			</div>
-			<div>
-				{contributorImages.map((image) => (
-					<img
-						className={contributorImageStyle}
-						src={image}
-						key={image}
-						alt=""
+			<div className={contributorsContainerStyle}>
+				{contributors.map((contributor) => (
+					<Contributor
+						key={contributor.login}
+						contributor={contributor}
+						className={contributorElementStyle}
 					/>
 				))}
 			</div>

--- a/packages/system/src/components/homepage/contributor.css.ts
+++ b/packages/system/src/components/homepage/contributor.css.ts
@@ -1,0 +1,13 @@
+import { style } from "@vanilla-extract/css"
+import { sprinkles } from "../../sprinkles/sprinkles.css"
+import { pxToRem } from "../../util/style-utils"
+
+export const contributorImageStyle = style([
+	sprinkles({ borderColor: "onSecondaryContainer" }),
+	{
+		maxWidth: pxToRem(72),
+		borderRadius: "50%",
+		borderWidth: pxToRem(4),
+		borderStyle: "solid",
+	},
+])

--- a/packages/system/src/components/homepage/contributor.stories.tsx
+++ b/packages/system/src/components/homepage/contributor.stories.tsx
@@ -1,0 +1,23 @@
+import { Story, Meta } from "@storybook/react"
+import {
+	Contributor as ContributorComponent,
+	ContributorProps,
+} from "./contributor"
+
+export default {
+	title: "Home/Contributor",
+	component: ContributorComponent,
+	args: {
+		contributor: {
+			login: "ktrz",
+			url: "https://github.com/ktrz",
+			avatarUrl: "https://github.com/ktrz.png",
+		},
+	},
+} as Meta
+
+const Template: Story<ContributorProps> = (args) => (
+	<ContributorComponent {...args} />
+)
+
+export const Contributor = Template.bind({})

--- a/packages/system/src/components/homepage/contributor.tsx
+++ b/packages/system/src/components/homepage/contributor.tsx
@@ -1,0 +1,28 @@
+import classNames from "classnames"
+import React from "react"
+import { contributorImageStyle } from "./contributor.css"
+
+export interface ContributorData {
+	login: string
+	url: string
+	avatarUrl: string
+}
+
+export interface ContributorProps extends React.ComponentPropsWithoutRef<"a"> {
+	contributor: ContributorData
+}
+
+export const Contributor = ({
+	className,
+	contributor: { avatarUrl, login, url },
+	...props
+}: ContributorProps) => (
+	<a {...props} href={url} target="_blank" rel="noreferrer">
+		<img
+			className={classNames(className, contributorImageStyle)}
+			src={avatarUrl}
+			key={avatarUrl}
+			alt={login}
+		/>
+	</a>
+)

--- a/packages/system/src/components/homepage/homepage.tsx
+++ b/packages/system/src/components/homepage/homepage.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames"
 import React from "react"
+import { ContributorData } from './contributor';
 import {
 	homepageContentContainerStyle,
 	homepageGutterStyle,
@@ -40,7 +41,7 @@ export interface HomepageProps extends React.ComponentPropsWithoutRef<"div"> {
 	communities: Community<string>[]
 	siteName: string
 	resourceCards: LinkCardProps[]
-	contributorsData: string[]
+	contributorsData: ContributorData[]
 }
 
 export function Homepage({
@@ -102,7 +103,7 @@ export function Homepage({
 					<Blogs blogs={blogs} />
 				</div>
 				<ContributorBanner
-					contributorImages={contributorsData}
+					contributors={contributorsData}
 				></ContributorBanner>
 				<div className={homepageTwoAndOneSectionStyle}>
 					<Books books={books} />

--- a/packages/system/src/github-util/get-contributors.ts
+++ b/packages/system/src/github-util/get-contributors.ts
@@ -1,0 +1,21 @@
+import { ContributorData } from "../components/homepage/contributor"
+
+interface ContributorApiData {
+	login: string
+	html_url: string
+	avatar_url: string
+}
+
+export const getContributorsData = (): Promise<ContributorData[]> => {
+	return fetch(
+		"https://api.github.com/repos/thisdot/framework.dev/contributors?anon=1"
+	)
+		.then((res) => res.json())
+		.then((data: ContributorApiData[]) =>
+			data.map((user) => ({
+				login: user.login,
+				url: user.html_url,
+				avatarUrl: user.avatar_url,
+			}))
+		)
+}


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [x] Behavior change

## Summary of change

* make left column text top-aligned
* change left column copy
* unify spacing between contributors' avatars
* add alt text to avatar images (user login)
* link contributor's avatar the GitHub profile page (open in new tab)
* change yellow background to transparent
* add contributors banner to landing page
* fix ContributorBanner story
* add Contributor story
* modified landing page margins for the new section

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->



<!-- Delete if your change is not a behaviour change -->

- [x] This change resolves #574
- [x] I have confirmed with a maintainer that this change is desired and been
      given the go-ahead to work on it in the relevant issue discussion
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the change and the rest of the site works as expected
- [x] If the change introduces new components, these have been added to
      `packages/system/src/components` with a `.stories.tsx` file that
      adequately renders possible variations of each component.
