### PR TITLE
Fix: comparison table not showing stats correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ e.g. `yarn dev:system` or `yarn dev:react`.
   to see compilation errors and dependencies not building correct (the symptom
   of which is often the browsers attempting to load `node:process` or other bare
   identifiers). This can be fixed by running
-  `rm -rf packages/react/node_modules && yarn build:react`
+  `rm -rf packages/site/node_modules && yarn build:react`
 
 ## Contributing
 

--- a/packages/system/src/components/comparison-table/index.tsx
+++ b/packages/system/src/components/comparison-table/index.tsx
@@ -45,6 +45,16 @@ export function ComparisonTable({
 	)
 
 	useEffect(() => {
+		const parsedLibraries = libraries.map((library) => {
+			if (library.package.includes("npmjs.com")) {
+				library.package = library.package.replace(
+					/(?:http(?:s)?:\/\/(?:www\.)?)npmjs\.com\/package\//,
+					""
+				)
+			}
+			return library
+		})
+
 		const abortController = new AbortController()
 
 		async function fetchData() {
@@ -55,17 +65,7 @@ export function ComparisonTable({
 					"Content-Type": "application/json",
 					Accept: "application/json",
 				},
-				body: JSON.stringify(
-					libraries.map((library) => {
-						if (library.package.includes("npmjs.com")) {
-							return library.package.replace(
-								/(?:http(?:s)?:\/\/(?:www\.)?)npmjs\.com\/package\//,
-								""
-							)
-						}
-						return library.package
-					})
-				),
+				body: JSON.stringify(parsedLibraries.map((library) => library.package)),
 				signal: abortController.signal,
 			})
 				.then((res) => res.json())
@@ -74,7 +74,8 @@ export function ComparisonTable({
 						return
 					}
 				})
-			const data: ILibrary[] = libraries.map((library) => {
+
+			const data: ILibrary[] = parsedLibraries.map((library) => {
 				return {
 					name: library.name,
 					author: library.author,


### PR DESCRIPTION
## Type of change

- [ ] Content addition
- [X] Bug fix
- [ ] Behavior change

## Summary of change

The npms.io API to fetch comparison table stats return the package name, not the full NPM URL. This fix parses the libraries array and transform the package value to only be the name we need.

Also fixed a typo in the README.md file.

![image](https://user-images.githubusercontent.com/39612839/208195851-4fd52fdc-1fb0-4dc3-b950-ff65fa5e80d4.png)


## Checklist

- [X] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [X] I have verified the fix works and introduces no further errors
