### PR TITLE
[svelte-kit-scss] Hide State Management from Libraries if we don't have content

### DIFF
--- a/packages/site/src/data/svelte/libraries.ts
+++ b/packages/site/src/data/svelte/libraries.ts
@@ -1,7 +1,6 @@
 import { Library } from "@framework/system/src/models/library"
 
 export const libraryTags = [
-	"state-management",
 	"data fetching",
 	"styling",
 	"component library",


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [x] Content addition
- [ ] Bug fix
- [ ] Behavior change

## Summary of change

## Checklist

- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [ ] I have searched all existing content and verified my additions are novel
      and unique
- [ ] The content was added to the end of the appropriate data list
- [ ] All required content fields are accurately populated
- [ ] All items are tagged with all relevant tags

<!-- Delete if your change is not a behaviour change -->

- [x] This change resolves #590 
- [x] I have confirmed with a maintainer that this change is desired and been
      given the go-ahead to work on it in the relevant issue discussion
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the change and the rest of the site works as expected
- [ ] If the change introduces new components, these have been added to
      `packages/system/src/components` with a `.stories.tsx` file that
      adequately renders possible variations of each component.
