### PR TITLE
fix: Landing page link icons size

### DIFF
--- a/packages/system/src/components/landing/link-card.css.ts
+++ b/packages/system/src/components/landing/link-card.css.ts
@@ -6,7 +6,7 @@ export const linkCardStyle = style([
 	sprinkles({
 		layout: "row",
 		borderRadius: 12,
-		alignItems: { desktop: 'start', mobile: 'center' },
+		alignItems: { desktop: "start", mobile: "center" },
 		flexDirection: { desktop: "column", mobile: "row" },
 		justifyContent: { desktop: "space-between", mobile: "flex-start" },
 		paddingLeft: 16,
@@ -103,7 +103,7 @@ export const linkCardIconStyle = style([
 		position: "absolute",
 		top: "50%",
 		transform: "translate(-50%, -50%)",
-		width: "50%",
+		width: "50% !important",
 	},
 ])
 

--- a/packages/system/src/components/landing/link-card.css.ts
+++ b/packages/system/src/components/landing/link-card.css.ts
@@ -103,7 +103,8 @@ export const linkCardIconStyle = style([
 		position: "absolute",
 		top: "50%",
 		transform: "translate(-50%, -50%)",
-		width: "50% !important",
+		width: "50%",
+		maxWidth: "50%",
 	},
 ])
 


### PR DESCRIPTION
I didn't see any tools for handling class specificity in the docs look like it might just end up being dependent on the order things are bundled by the build system. So I went with a good old fashioned !important to fix the issue for now 

Specificity Issue
![Screen Shot 2023-01-11 at 5 45 25 PM](https://user-images.githubusercontent.com/3721977/211945798-cd6e90c3-b571-44c0-8169-82ab70c1b997.png)

Before
![Screen Shot 2023-01-11 at 7 17 58 PM](https://user-images.githubusercontent.com/3721977/211945952-04dff8c4-ca87-4db2-9564-9362910dacdb.png)

After adding !important
![Screen Shot 2023-01-11 at 7 17 11 PM](https://user-images.githubusercontent.com/3721977/211946003-1c63b288-51eb-4457-b38a-e0b15d629e15.png)
