### PR TITLE
updated the react native podcast image

### DIFF
--- a/packages/site/src/data/react/podcasts.ts
+++ b/packages/site/src/data/react/podcasts.ts
@@ -8,7 +8,7 @@ export const podcastTags = [
 	"redux",
 ] as const
 
-export const podcasts: Podcast<typeof podcastTags[number]>[] = [
+export const podcasts: Podcast<(typeof podcastTags)[number]>[] = [
 	{
 		title: "Modern Web",
 		image:
@@ -52,7 +52,7 @@ export const podcasts: Podcast<typeof podcastTags[number]>[] = [
 	{
 		title: "React Native Podcast",
 		image:
-			"https://uploads-ssl.webflow.com/5f58b425f8d1c77413f14703/602134a13b87901e72b9759b_RGB_Logo%201.svg",
+			"https://global-uploads.webflow.com/5f58b425f8d1c77413f14703/605b71a5676cee7fcc8daca3_oopen_graph_podcast.png",
 		hosts: ["Mike Grabowski"],
 		description:
 			"Join our experts as they discuss everything React Native Latest Episode 9 React Native News",


### PR DESCRIPTION
## Type of change

Changed the image for The React Native Podcast podcast item.

<img width="267" alt="image" src="https://user-images.githubusercontent.com/9042219/217112730-c9bfb728-4e07-4caf-9e45-e9279cbb9ca6.png">


- [ ] Content addition
- [ ] Bug fix
- [x] Behavior change

## Summary of change

<!-- Delete if your change is not a behaviour change -->

- [x] This change resolves #533 
- [x] I have confirmed with a maintainer that this change is desired and been
      given the go-ahead to work on it in the relevant issue discussion
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the change and the rest of the site works as expected