### PR TITLE
fix: unify freeCodeCamp naming conventions

### DIFF
--- a/packages/site/src/data/deno/blogs.ts
+++ b/packages/site/src/data/deno/blogs.ts
@@ -51,7 +51,7 @@ export const blogs: Blog<typeof blogTags[number]>[] = [
 	},
 	{
 		title: "The Deno handbook",
-		author: "FreeCodeCamp",
+		author: "freeCodeCamp",
 		description: "A TypeScript Runtime Tutorial with Code Examples",
 		image: "https://github.com/freeCodeCamp.png",
 		href: "https://www.freecodecamp.org/news/the-deno-handbook/",

--- a/packages/site/src/data/deno/courses.ts
+++ b/packages/site/src/data/deno/courses.ts
@@ -93,7 +93,7 @@ export const courses: Course<(typeof courseTags)[number]>[] = [
 	},
 	{
 		title: "Deno Course - Better than Node.js?",
-		author: "freeCodeCamp.org",
+		author: "freeCodeCamp",
 		description:
 			"Learn how to use Deno in this complete course. Deno is a Node.js alternative created by the same person who created Node.js. In this tutorial course, you will learn how to build real apps with Deno. You will also learn the basics of the TypeScript. You will see how to use Deno to build a survey app with a REST API using MongoDB.",
 		paymentType: "free",

--- a/packages/site/src/data/react/courses.ts
+++ b/packages/site/src/data/react/courses.ts
@@ -31,7 +31,7 @@ export const courseTags = [
 	"static site generation",
 ] as const
 
-export const courses: Course<(typeof courseTags)[number]>[] = [
+export const courses: Course<typeof courseTags[number]>[] = [
 	{
 		title: "Code 15 React Projects - Complete Course",
 		author: "John Smilga",
@@ -96,7 +96,7 @@ export const courses: Course<(typeof courseTags)[number]>[] = [
 	},
 	{
 		title: "Front End Development - React course",
-		author: "FreeCodeCamp",
+		author: "freeCodeCamp",
 		image: "https://github.com/freeCodeCamp.png",
 		description:
 			"In the Front End Development Libraries Certification, you'll learn how to style your site quickly with Bootstrap. You'll also learn how add logic to your CSS styles and extend them with Sass.",
@@ -116,7 +116,7 @@ export const courses: Course<(typeof courseTags)[number]>[] = [
 	},
 	{
 		title: "React crash course",
-		author: "FreeCodeCamp",
+		author: "freeCodeCamp",
 		image: "https://github.com/freeCodeCamp.png",
 		description:
 			"This is a full premium course. Learn React.js from the ground up with fundamentals to more intermediate and advanced topics. You will learn by building a real app!",
@@ -228,7 +228,7 @@ export const courses: Course<(typeof courseTags)[number]>[] = [
 	},
 	{
 		title: "React TypeScript Tutorial - Build a Quiz App",
-		author: "FreeCodeCamp",
+		author: "freeCodeCamp",
 		image: "https://github.com/freeCodeCamp.png",
 		description:
 			"Learn how to use React and TypeScript to create a quiz app project. You will also learn how to use Styled-Components with React.",

--- a/packages/site/src/data/svelte/blogs.ts
+++ b/packages/site/src/data/svelte/blogs.ts
@@ -171,8 +171,8 @@ export const blogs: Blog<typeof blogTags[number]>[] = [
 		tags: [],
 	},
 	{
-		title: "Freecodecamp",
-		author: "Freecodecamp contributors",
+		title: "freeCodeCamp",
+		author: "freeCodeCamp contributors",
 		description: "Svelte related blogs",
 		image:
 			"https://cdn.icon-icons.com/icons2/3206/PNG/512/free_code_camp_icon_195851.png",

--- a/packages/system/src/util/example-content.ts
+++ b/packages/system/src/util/example-content.ts
@@ -29,7 +29,7 @@ export type ExampleTag = typeof exampleTags[number]
 export const exampleCourses: Course<ExampleTag>[] = [
 	{
 		title: "Code 15 React Projects - Complete Course",
-		author: "freeCodeCamp.org",
+		author: "freeCodeCamp",
 		image: logo1,
 		description:
 			"Improve your skills with the React JavaScript library by building 15 projects using React.",


### PR DESCRIPTION
## Type of change

This is a content change to give freeCodeCamp naming consistent and correct convention

Closes #531 

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

<!-- Delete if your change is not a content addition -->

- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have searched all existing content and verified my additions are novel
      and unique
- [ ] The content was added to the end of the appropriate data list
- [ ] All required content fields are accurately populated
- [ ] All items are tagged with all relevant tags

<!-- Delete if your change is not a bug fix -->

- [ ] This fix resolves #<!-- replace with issue number -->
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors

<!-- Delete if your change is not a behaviour change -->

- [ ] This change resolves #<!-- replace with issue number -->
- [ ] I have confirmed with a maintainer that this change is desired and been
      given the go-ahead to work on it in the relevant issue discussion
- [ ] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [ ] I have verified the change and the rest of the site works as expected
- [ ] If the change introduces new components, these have been added to
      `packages/system/src/components` with a `.stories.tsx` file that
      adequately renders possible variations of each component.
