### PR TITLE
Fix/679 angular resource sorting

### DIFF
--- a/packages/site/src/data/angular/blogs.ts
+++ b/packages/site/src/data/angular/blogs.ts
@@ -1,34 +1,7 @@
 import { Blog } from "@framework/system/src/models/blog"
 export const blogTags = [] as const
 
-export const blogs: Blog<typeof blogTags[number]>[] = [
-	{
-		title: "This Dot Blog",
-		author: "This Dot Labs",
-		description:
-			"Variety of topics related to Angular, written by the team at This Dot",
-		image: "https://github.com/thisdot.png",
-		href: "https://www.thisdot.co/blog/?filter=Angular#result",
-		tags: [],
-	},
-	{
-		title: "This is Angular",
-		author: "Dev.to Contributors",
-		description: "Free, open and honest Angular education.",
-		image:
-			"https://dev-to-uploads.s3.amazonaws.com/uploads/organization/profile_image/3316/b77c881d-527b-4295-9e3c-3aa9072a4671.png",
-		href: "https://dev.to/this-is-angular",
-		tags: [],
-	},
-	{
-		title: "InDepthDev",
-		author: "InDepthDev",
-		description:
-			"inDepthDev is a community of experienced software engineers with a common goal of constant professional growth and inclination to help others.",
-		image: "https://github.com/indepth-dev.png",
-		href: "https://indepth.dev/angular",
-		tags: [],
-	},
+export const blogs: Blog<(typeof blogTags)[number]>[] = [
 	{
 		title: "Angular University",
 		author: "Vasco Cavalheiro",
@@ -55,6 +28,33 @@ export const blogs: Blog<typeof blogTags[number]>[] = [
 			"The Journal for Angular - covering the entire Angular stack and best practices.",
 		image: "https://ng-journal.com/assets/ng-journal.png",
 		href: "https://ng-journal.com/blog/",
+		tags: [],
+	},
+	{
+		title: "This is Angular",
+		author: "Dev.to Contributors",
+		description: "Free, open and honest Angular education.",
+		image:
+			"https://dev-to-uploads.s3.amazonaws.com/uploads/organization/profile_image/3316/b77c881d-527b-4295-9e3c-3aa9072a4671.png",
+		href: "https://dev.to/this-is-angular",
+		tags: [],
+	},
+	{
+		title: "InDepthDev",
+		author: "InDepthDev",
+		description:
+			"inDepthDev is a community of experienced software engineers with a common goal of constant professional growth and inclination to help others.",
+		image: "https://github.com/indepth-dev.png",
+		href: "https://indepth.dev/angular",
+		tags: [],
+	},
+	{
+		title: "This Dot Blog",
+		author: "This Dot Labs",
+		description:
+			"Variety of topics related to Angular, written by the team at This Dot",
+		image: "https://github.com/thisdot.png",
+		href: "https://www.thisdot.co/blog/?filter=Angular#result",
 		tags: [],
 	},
 ]

--- a/packages/site/src/data/angular/communities.ts
+++ b/packages/site/src/data/angular/communities.ts
@@ -12,15 +12,6 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		tags: [],
 	},
 	{
-		name: "Angular Meetup / State of Angular",
-		description:
-			"This Dot hosted events with members of the Angular community. Live chats about the current state of Angular, upcoming features, and mentoring.",
-		image: "https://github.com/thisdot.png",
-		type: "Live Events",
-		href: "https://www.angularmeetup.com/",
-		tags: ["meetups"],
-	},
-	{
 		name: "Angular Community Meetup",
 		description:
 			"Angular Community is a virtual meetup that is held twice a month: once for European and African time zones, and once for American timezones.",
@@ -71,6 +62,15 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		type: "Live Events",
 		href: "https://ng-be.org/",
 		tags: ["conferences"],
+	},
+	{
+		name: "Angular Meetup / State of Angular",
+		description:
+			"This Dot hosted events with members of the Angular community. Live chats about the current state of Angular, upcoming features, and mentoring.",
+		image: "https://github.com/thisdot.png",
+		type: "Live Events",
+		href: "https://www.angularmeetup.com/",
+		tags: ["meetups"],
 	},
 	{
 		name: "Front Stage",

--- a/packages/site/src/data/angular/podcasts.ts
+++ b/packages/site/src/data/angular/podcasts.ts
@@ -2,18 +2,7 @@ import { Podcast } from "@framework/system/src/models/podcast"
 
 export const podcastTags = ["general"] as const
 
-export const podcasts: Podcast<typeof podcastTags[number]>[] = [
-	{
-		title: "Modern Web",
-		image:
-			"https://pbcdn1.podbean.com/imglogo/image-logo/984467/modern_web_9bpnd.jpg",
-		hosts: ["This Dot Media"],
-		description:
-			"Modern Web is a podcast that explores next generation frameworks, standards, and techniques.",
-		rss: "https://feed.podbean.com/modernweb/feed.xml",
-		href: "https://modernweb.podbean.com",
-		tags: ["general"],
-	},
+export const podcasts: Podcast<(typeof podcastTags)[number]>[] = [
 	{
 		title: "Angular Experience",
 		image: "https://ngxp.show/assets/images/ngxpSiteImage2%20(1).png",
@@ -43,6 +32,17 @@ export const podcasts: Podcast<typeof podcastTags[number]>[] = [
 			"The Angular Plus Show is the home of ng-conf's official all-Angular podcast. It covers a wide variety of non-Angular topics as well.",
 		rss: "https://www.spreaker.com/show/4175221/episodes/feed",
 		href: "https://www.spreaker.com/show/angular-show",
+		tags: ["general"],
+	},
+	{
+		title: "Modern Web",
+		image:
+			"https://pbcdn1.podbean.com/imglogo/image-logo/984467/modern_web_9bpnd.jpg",
+		hosts: ["This Dot Media"],
+		description:
+			"Modern Web is a podcast that explores next generation frameworks, standards, and techniques.",
+		rss: "https://feed.podbean.com/modernweb/feed.xml",
+		href: "https://modernweb.podbean.com",
 		tags: ["general"],
 	},
 ]


### PR DESCRIPTION
## Type of change

- [ ] Content addition
- [ ] Bug fix
- [x] Behavior change

## Summary of change

Sorts resources for so Angular-specific titles appear ahead of This Dot branded titles.

## Checklist

- [x] This change resolves #679 
- [x] I have confirmed with a maintainer that this change is desired and been
      given the go-ahead to work on it in the relevant issue discussion
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the change and the rest of the site works as expected
