### PR TITLE
Fix/682 deno resource sorting

### DIFF
--- a/packages/site/src/data/deno/blogs.ts
+++ b/packages/site/src/data/deno/blogs.ts
@@ -2,16 +2,7 @@ import { Blog } from "@framework/system/src/models/blog"
 
 export const blogTags = [] as const
 
-export const blogs: Blog<typeof blogTags[number]>[] = [
-	{
-		title: "This Dot Blog",
-		author: "This Dot Labs",
-		description:
-			"Variety of topics related to JavaScript, written by the team at This Dot",
-		image: "https://github.com/thisdot.png",
-		href: "https://www.thisdot.co/blog/",
-		tags: [],
-	},
+export const blogs: Blog<(typeof blogTags)[number]>[] = [
 	{
 		title: "Deno Blog",
 		author: "Deno",
@@ -32,24 +23,6 @@ export const blogs: Blog<typeof blogTags[number]>[] = [
 		tags: [],
 	},
 	{
-		title: "Ultimate Courses - Deno blogs",
-		author: "Ultimate Courses",
-		description: "All about Deno, the new JavaScript and TypeScript runtime.",
-		image:
-			"https://ultimatecourses.com/assets/logo-ef24a2d3b6a0febba9ff80a1b01d632db750feb083442d0071dff7426762e0c2.svg",
-		href: "https://ultimatecourses.com/blog/category/deno/",
-		tags: [],
-	},
-	{
-		title: "LogRocket Blog",
-		author: "LogRocket",
-		description: "This is a blog dedicated to all things web development",
-		image:
-			"https://pbs.twimg.com/profile_images/1326191211850440708/uQc_hHbU_400x400.jpg",
-		href: "https://blog.logrocket.com/tag/deno/",
-		tags: [],
-	},
-	{
 		title: "The Deno handbook",
 		author: "freeCodeCamp",
 		description: "A TypeScript Runtime Tutorial with Code Examples",
@@ -64,6 +37,33 @@ export const blogs: Blog<typeof blogTags[number]>[] = [
 			"Deno.js is the better Node.js. Or, at least, that's the goal. Here's what sets Deno apart from Node and my opinion on whether you should make the switch.",
 		image: "https://github.com/Academind.png",
 		href: "https://academind.com/tutorials/denojs-first-look",
+		tags: [],
+	},
+	{
+		title: "Ultimate Courses - Deno blogs",
+		author: "Ultimate Courses",
+		description: "All about Deno, the new JavaScript and TypeScript runtime.",
+		image:
+			"https://ultimatecourses.com/assets/logo-ef24a2d3b6a0febba9ff80a1b01d632db750feb083442d0071dff7426762e0c2.svg",
+		href: "https://ultimatecourses.com/blog/category/deno/",
+		tags: [],
+	},
+	{
+		title: "This Dot Blog",
+		author: "This Dot Labs",
+		description:
+			"Variety of topics related to JavaScript, written by the team at This Dot",
+		image: "https://github.com/thisdot.png",
+		href: "https://www.thisdot.co/blog/",
+		tags: [],
+	},
+	{
+		title: "LogRocket Blog",
+		author: "LogRocket",
+		description: "This is a blog dedicated to all things web development",
+		image:
+			"https://pbs.twimg.com/profile_images/1326191211850440708/uQc_hHbU_400x400.jpg",
+		href: "https://blog.logrocket.com/tag/deno/",
 		tags: [],
 	},
 ]

--- a/packages/site/src/data/deno/podcasts.ts
+++ b/packages/site/src/data/deno/podcasts.ts
@@ -10,6 +10,17 @@ export const podcastTags = [
 
 export const podcasts: Podcast<(typeof podcastTags)[number]>[] = [
 	{
+		title: "Deno Developer Show",
+		description:
+			"This show talks about utilizing your Javascript or TypeScript skills so you can do backend development in Deno, a robust and secure runtime for Javascript and TypeScript.",
+		hosts: ["Authvow, LLC"],
+		href: "https://denodeveloper.buzzsprout.com/",
+		rss: "https://feeds.buzzsprout.com/1951607.rss",
+		image:
+			"https://denodeveloper.buzzsprout.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCSWJSMndNPSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--2fa37dace7e149b96e9f27431e7355109f633c65/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRFRZd01IZzJNREJlQmpzR1ZEb01aM0poZG1sMGVVa2lDMk5sYm5SbGNnWTdCbFE2QzJWNGRHVnVkRWtpRERZd01IZzJNREFHT3daVU9neHhkV0ZzYVhSNWFWVTZEMk52Ykc5eWMzQmhZMlZKSWdselVrZENCanNHVkE9PSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8a9b4b1bc245a46b538f72d4d9b2ab0a7fbe8ac1/denoDeveloperShowLarge_noSeason.jpg",
+		tags: ["how-to", "technology"],
+	},
+	{
 		title: "Modern Web",
 		image:
 			"https://pbcdn1.podbean.com/imglogo/image-logo/984467/modern_web_9bpnd.jpg",
@@ -48,17 +59,6 @@ export const podcasts: Podcast<(typeof podcastTags)[number]>[] = [
 		href: "https://thewebplatformpodcast.com/",
 		rss: "https://thewebplatformpodcast.com/rss",
 		image: "https://i.scdn.co/image/79e44158769aaa756916b5ee9accf796227c5115",
-		tags: ["how-to", "technology"],
-	},
-	{
-		title: "Deno Developer Show",
-		description:
-			"This show talks about utilizing your Javascript or TypeScript skills so you can do backend development in Deno, a robust and secure runtime for Javascript and TypeScript.",
-		hosts: ["Authvow, LLC"],
-		href: "https://denodeveloper.buzzsprout.com/",
-		rss: "https://feeds.buzzsprout.com/1951607.rss",
-		image:
-			"https://denodeveloper.buzzsprout.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCSWJSMndNPSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--2fa37dace7e149b96e9f27431e7355109f633c65/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRFRZd01IZzJNREJlQmpzR1ZEb01aM0poZG1sMGVVa2lDMk5sYm5SbGNnWTdCbFE2QzJWNGRHVnVkRWtpRERZd01IZzJNREFHT3daVU9neHhkV0ZzYVhSNWFWVTZEMk52Ykc5eWMzQmhZMlZKSWdselVrZENCanNHVkE9PSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8a9b4b1bc245a46b538f72d4d9b2ab0a7fbe8ac1/denoDeveloperShowLarge_noSeason.jpg",
 		tags: ["how-to", "technology"],
 	},
 	{


### PR DESCRIPTION
## Type of change

- [ ] Content addition
- [ ] Bug fix
- [x] Behavior change

## Summary of change

Sorts resources for so React-specific titles appear ahead of This Dot branded titles.

## Checklist

- [x] This change resolves #682 
- [x] I have confirmed with a maintainer that this change is desired and been
      given the go-ahead to work on it in the relevant issue discussion
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the change and the rest of the site works as expected
