### PR TITLE
sorted vue communities

### DIFF
--- a/packages/site/src/data/vue/communities.ts
+++ b/packages/site/src/data/vue/communities.ts
@@ -14,24 +14,6 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		tags: [],
 	},
 	{
-		name: "Vue Meetup / State of Vue",
-		description:
-			"This Dot Media presents Vue Contributor Day! The goal of this event is to not only give important updates to the community, but also as a forum to provide a voice for anyone using Vue.js to have direct access to core contributors and authors of various libraries and frameworks through live chat and an online broadcast.",
-		image: "https://github.com/thisdot.png",
-		type: "Live Events",
-		href: "https://www.vuemeetup.com/",
-		tags: ["meetups"],
-	},
-	{
-		name: "DigitalOcean Community",
-		description:
-			"DigitalOcean Community is a blog related to general Web development, with categories spanning across CSS, general JavaScript, and frameworks like Vue",
-		image: "https://www.digitalocean.com/_next/static/media/logo.87a8f3b8.svg",
-		type: "forum",
-		href: "https://www.digitalocean.com/community/tags/vue-js",
-		tags: [],
-	},
-	{
 		name: "VueConf Toronto",
 		description:
 			"VueConf Toronto is a Canadian conference with talks and workshops from Vue.js core team members and industry experts.",
@@ -82,6 +64,24 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		type: "Online and Live Events",
 		href: "https://vuejslive.com/",
 		tags: ["conferences"],
+	},
+	{
+		name: "DigitalOcean Community",
+		description:
+			"DigitalOcean Community is a blog related to general Web development, with categories spanning across CSS, general JavaScript, and frameworks like Vue",
+		image: "https://www.digitalocean.com/_next/static/media/logo.87a8f3b8.svg",
+		type: "forum",
+		href: "https://www.digitalocean.com/community/tags/vue-js",
+		tags: [],
+	},
+	{
+		name: "Vue Meetup / State of Vue",
+		description:
+			"This Dot Media presents Vue Contributor Day! The goal of this event is to not only give important updates to the community, but also as a forum to provide a voice for anyone using Vue.js to have direct access to core contributors and authors of various libraries and frameworks through live chat and an online broadcast.",
+		image: "https://github.com/thisdot.png",
+		type: "Live Events",
+		href: "https://www.vuemeetup.com/",
+		tags: ["meetups"],
 	},
 	{
 		name: "Front Stage",

--- a/packages/site/src/data/vue/podcasts.ts
+++ b/packages/site/src/data/vue/podcasts.ts
@@ -2,18 +2,7 @@ import { Podcast } from "@framework/system/src/models/podcast"
 
 export const podcastTags = ["general", "GraphQL", "vue", "quasar"] as const
 
-export const podcasts: Podcast<typeof podcastTags[number]>[] = [
-	{
-		title: "Modern Web",
-		image:
-			"https://pbcdn1.podbean.com/imglogo/image-logo/984467/modern_web_9bpnd.jpg",
-		hosts: ["ThisDot Labs"],
-		description:
-			"Modern Web is a podcast that explores next generation frameworks, standards, and techniques.",
-		rss: "https://www.podbean.com/site/podcatcher/index/blog/7YqKYcoGcvP",
-		href: "https://modernweb.podbean.com/",
-		tags: ["general"],
-	},
+export const podcasts: Podcast<(typeof podcastTags)[number]>[] = [
 	{
 		title: "Views on Vue",
 		image:
@@ -73,5 +62,16 @@ export const podcasts: Podcast<typeof podcastTags[number]>[] = [
 		rss: "https://feeds.transistor.fm/quasar-vue-life",
 		href: "https://quasarcast.com/podcasts/quasar-life",
 		tags: ["vue", "quasar"],
+	},
+	{
+		title: "Modern Web",
+		image:
+			"https://pbcdn1.podbean.com/imglogo/image-logo/984467/modern_web_9bpnd.jpg",
+		hosts: ["ThisDot Labs"],
+		description:
+			"Modern Web is a podcast that explores next generation frameworks, standards, and techniques.",
+		rss: "https://www.podbean.com/site/podcatcher/index/blog/7YqKYcoGcvP",
+		href: "https://modernweb.podbean.com/",
+		tags: ["general"],
 	},
 ]


### PR DESCRIPTION
## Type of change

- [ ] Content addition
- [ ] Bug fix
- [x] Behavior change

## Summary of change

Sorts resources for so React-specific titles appear ahead of This Dot branded titles.

## Checklist

- [x] This change resolves #681 
- [x] I have confirmed with a maintainer that this change is desired and been
      given the go-ahead to work on it in the relevant issue discussion
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the change and the rest of the site works as expected
