### PR TITLE
feat: add retries to getContributorsData to handle periodic failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
 		"lint-staged": "^13.1.0",
 		"mini-css-extract-plugin": "^2.7.2",
 		"npm-run-all": "^4.1.5",
+		"p-retry": "^5.1.2",
 		"plop": "^3.1.1",
 		"prettier": "^2.8.2",
 		"storybook-addon-themes": "^6.1.0",

--- a/packages/system/src/github-util/get-contributors.ts
+++ b/packages/system/src/github-util/get-contributors.ts
@@ -1,3 +1,4 @@
+import pRetry, { AbortError } from "p-retry"
 import { ContributorData } from "../components/homepage/contributor"
 
 interface ContributorApiData {
@@ -6,20 +7,41 @@ interface ContributorApiData {
 	avatar_url: string
 }
 
-export const getContributorsData = (): Promise<ContributorData[]> => {
-	return fetch(
-		"https://api.github.com/repos/thisdot/framework.dev/contributors?anon=1"
-	)
-		.then((res) => res.json())
-		.then((data: ContributorApiData[]) => {
-			try {
-				return data.map((user) => ({
-					login: user.login,
-					url: user.html_url,
-					avatarUrl: user.avatar_url,
-				}))
-			} catch (e) {
-				return []
-			}
+export const getContributorsData = async (): Promise<ContributorData[]> => {
+	const runFetch = async () => {
+		const abortError = new AbortError("Failed to fetch contributors")
+		const response = await fetch(
+			"https://api.github.com/repos/thisdot/framework.dev/contributors?anon=1"
+		)
+		if (!response.ok) {
+			throw abortError
+		}
+		const data = await response.json()
+		if (!data) {
+			throw abortError
+		}
+
+		return data
+	}
+
+	try {
+		const data = await pRetry(runFetch, {
+			retries: 3,
+			onFailedAttempt: (error) => {
+				console.log(
+					`getContributorsData Failure: Attempt ${error.attemptNumber} failed. There are ${error.retriesLeft} retries left.`
+				)
+			},
 		})
+
+		return data.map((user: ContributorApiData) => ({
+			login: user.login,
+			url: user.html_url,
+			avatarUrl: user.avatar_url,
+		}))
+	} catch (error) {
+		throw new Error(
+			"Failed to fetch contributors. Please try rebuilding the website."
+		)
+	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3135,6 +3135,11 @@
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.20.2.tgz#97d26e00cd4a0423b4af620abecf3e6f442b7975"
   integrity sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==
 
+"@types/retry@0.12.1":
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.1.tgz#d8f1c0d0dc23afad6dc16a9e993a0865774b4065"
+  integrity sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==
+
 "@types/scheduler@*":
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
@@ -10683,6 +10688,14 @@ p-map@^4.0.0:
   dependencies:
     aggregate-error "^3.0.0"
 
+p-retry@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-5.1.2.tgz#c16eaee4f2016f9161d12da40d3b8b0f2e3c1b76"
+  integrity sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==
+  dependencies:
+    "@types/retry" "0.12.1"
+    retry "^0.13.1"
+
 p-timeout@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
@@ -12097,6 +12110,11 @@ retext@^8.1.0:
     retext-latin "^3.0.0"
     retext-stringify "^3.0.0"
     unified "^10.0.0"
+
+retry@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
 reusify@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
## Changes

- Adds retry support to getContributorsData api request

## Details
There is an issue where periodically and not infrequently the getContributorsData api request fails when building the framework.dev sites. This leads to a failed build or a contributors section without a list of contributors (depending on whether or not you swallow the error) 

This PR adds retries to the request so that it will try to make the request 3 times before giving up and killing the build

Closes #690 