### PR TITLE
feat: Resource Card Max Width

### DIFF
--- a/packages/system/src/components/cards/card-layouts.css.ts
+++ b/packages/system/src/components/cards/card-layouts.css.ts
@@ -17,6 +17,9 @@ export const titleFirstCardGrid = style([
 			[breakpoints.tablet]: {
 				gridTemplateColumns: "repeat(auto-fit, minmax(360px, 1fr))",
 			},
+			[breakpoints.desktop]: {
+				gridTemplateColumns: "repeat(auto-fit, minmax(360px, .5fr))",
+			},
 		},
 	},
 ])


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Content addition
- [ ] Bug fix
- [x] Behavior change

## Summary of change

<!-- Provide a brief summary of what changes this PR includes, like "added some popular React podcasts" or "fixed navigation menu getting cut off on screens narrower than 320px" -->

This PR sets the max width of a resource card on desktop size screens to half the available free space. In practice this just limits single cards on wide screens from only take 1/2 the space as if there were 2 cols set.

Screenshot examples:

![Screen Shot 2023-02-15 at 12 54 40 PM](https://user-images.githubusercontent.com/3721977/219113350-037af0d2-81df-4b08-9b84-b0427324dda5.png)
![Screen Shot 2023-02-15 at 12 55 09 PM](https://user-images.githubusercontent.com/3721977/219113351-aa79837b-71f5-49b2-b8a4-d2b2c6a1b954.png)
![Screen Shot 2023-02-15 at 12 55 16 PM](https://user-images.githubusercontent.com/3721977/219113355-3671ace1-53eb-4ad6-8353-f1a3bdd1b7a5.png)

## Checklist

<!-- Delete if your change is not a behaviour change -->

- [x] This change resolves #691 
- [x] I have confirmed with a maintainer that this change is desired and been
      given the go-ahead to work on it in the relevant issue discussion
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the change and the rest of the site works as expected
- [x] If the change introduces new components, these have been added to
      `packages/system/src/components` with a `.stories.tsx` file that
      adequately renders possible variations of each component.
