### PR TITLE
fix: Attempt to fix contributors list fetching

### DIFF
--- a/packages/system/src/github-util/get-contributors.ts
+++ b/packages/system/src/github-util/get-contributors.ts
@@ -14,10 +14,12 @@ export const getContributorsData = async (): Promise<ContributorData[]> => {
 			"https://api.github.com/repos/thisdot/framework.dev/contributors?anon=1"
 		)
 		if (!response.ok) {
+			await new Promise((resolve) => setTimeout(resolve, 1000))
 			throw abortError
 		}
 		const data = await response.json()
 		if (!data) {
+			await new Promise((resolve) => setTimeout(resolve, 1000))
 			throw abortError
 		}
 
@@ -31,8 +33,6 @@ export const getContributorsData = async (): Promise<ContributorData[]> => {
 				console.log(
 					`getContributorsData Failure: Attempt ${error.attemptNumber} failed. There are ${error.retriesLeft} retries left.`
 				)
-				// resolve promise after 1 second
-				return new Promise((resolve) => setTimeout(resolve, 1000))
 			},
 		})
 

--- a/packages/system/src/github-util/get-contributors.ts
+++ b/packages/system/src/github-util/get-contributors.ts
@@ -13,7 +13,12 @@ export const getContributorsData = async (): Promise<ContributorData[]> => {
 	const runFetch = async () => {
 		const error = new Error("Failed to fetch contributors")
 		const response = await fetch(
-			"https://api.github.com/repos/thisdot/framework.dev/contributors?anon=1"
+			"https://api.github.com/repos/thisdot/framework.dev/contributors?anon=1",
+			{
+				headers: {
+					Authorization: `Token ${process.env.GITHUB_API_ACCESS_TOKEN}`,
+				},
+			}
 		)
 		if (!response.ok) {
 			throw error

--- a/packages/system/src/github-util/get-contributors.ts
+++ b/packages/system/src/github-util/get-contributors.ts
@@ -31,6 +31,8 @@ export const getContributorsData = async (): Promise<ContributorData[]> => {
 				console.log(
 					`getContributorsData Failure: Attempt ${error.attemptNumber} failed. There are ${error.retriesLeft} retries left.`
 				)
+				// resolve promise after 1 second
+				return new Promise((resolve) => setTimeout(resolve, 1000))
 			},
 		})
 


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change

Public API calls to the GitHub API get aggressively rate limited. This PR adds a PAT to the builds to authenticate the GH api requests to avoid being rate limited, triggering failures, while the sites are building.

I created a fine grained access token with no permissions on my personal account to accomplish this. This seems like the ideal route over a legacy PAT for security reasons. Fine grained PAT's need to be refreshed every few months though it appears. Will probably one to generate one from the labs github account for this.

<!-- Provide a brief summary of what changes this PR includes, like "added some popular React podcasts" or "fixed navigation menu getting cut off on screens narrower than 320px" -->

## Checklist

<!-- Delete if your change is not a bug fix -->

- [x] This fix resolves #706
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors
