### PR TITLE
fix: replace broken Digital Ocean image

### DIFF
--- a/packages/site/src/data/vue/communities.ts
+++ b/packages/site/src/data/vue/communities.ts
@@ -69,7 +69,8 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'DigitalOcean Community',
 		description:
 			'DigitalOcean Community is a blog related to general Web development, with categories spanning across CSS, general JavaScript, and frameworks like Vue',
-		image: 'https://www.digitalocean.com/_next/static/media/logo.87a8f3b8.svg',
+		image:
+			'https://upload.wikimedia.org/wikipedia/commons/thumb/f/ff/DigitalOcean_logo.svg/1200px-DigitalOcean_logo.svg.png',
 		type: 'forum',
 		href: 'https://www.digitalocean.com/community/tags/vue-js',
 		tags: [],


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change
- Replaces broken Digital Ocean image with a new one

![Screenshot 2023-02-20 at 10 37 42 AM](https://user-images.githubusercontent.com/20880360/220179471-03afac31-07f6-4440-a779-6b17bb2abe39.png)



<!-- Provide a brief summary of what changes this PR includes, like "added some popular React podcasts" or "fixed navigation menu getting cut off on screens narrower than 320px" -->

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

<!-- Delete if your change is not a bug fix -->

- [x] This fix resolves #716 
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors

