### PR TITLE
fix: applying header authorization when in prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,6 @@ Framework.dev is a knowledge base for different frontend frameworks
 - `@framework/site` is the code for the actual sites. Each site has a different
   set of data in the `src/data` folder.
 
-## Creating the .env file
-
-Add the following contents to the `.env`. This file will be used to set the node
-environment to development.
-
-```bash
-NODE_ENV=development
-
-```
-
 ## Running locally
 
 First of all, `yarn install`

--- a/README.md
+++ b/README.md
@@ -9,12 +9,27 @@ Framework.dev is a knowledge base for different frontend frameworks
 - `@framework/site` is the code for the actual sites. Each site has a different
   set of data in the `src/data` folder.
 
+## Creating the .env file
+
+Run the following code below to copy the contents of the `.env.example` file
+over to a new `.env` file. This file will be used to set the node environment to
+development.
+
+```bash
+# macOS/Linux
+cp .env.example .env
+
+# Windows
+copy .env.example .env
+
+```
+
 ## Running locally
 
 First of all, `yarn install`
 
-Dev servers for specific packages can be run with `yarn dev:<package-name>`
-e.g. `yarn dev:system` or `yarn dev:react`.
+Dev servers for specific packages can be run with `yarn dev:<package-name>` e.g.
+`yarn dev:system` or `yarn dev:react`.
 
 ### Known issues
 

--- a/README.md
+++ b/README.md
@@ -11,16 +11,11 @@ Framework.dev is a knowledge base for different frontend frameworks
 
 ## Creating the .env file
 
-Run the following code below to copy the contents of the `.env.example` file
-over to a new `.env` file. This file will be used to set the node environment to
-development.
+Add the following contents to the `.env`. This file will be used to set the node
+environment to development.
 
 ```bash
-# macOS/Linux
-cp .env.example .env
-
-# Windows
-copy .env.example .env
+NODE_ENV=development
 
 ```
 

--- a/packages/system/src/github-util/get-contributors.ts
+++ b/packages/system/src/github-util/get-contributors.ts
@@ -10,14 +10,21 @@ interface ContributorApiData {
 export const getContributorsData = async (): Promise<ContributorData[]> => {
 	const runFetch = async () => {
 		const abortError = new AbortError('Failed to fetch contributors')
-		const response = await fetch(
-			'https://api.github.com/repos/thisdot/framework.dev/contributors?anon=1',
-			{
-				headers: {
-					Authorization: `Token ${process.env.GITHUB_API_ACCESS_TOKEN}`,
-				},
-			}
-		)
+		const response =
+			process.env.NODE_ENV !== 'development'
+				? await fetch(
+						'https://api.github.com/repos/thisdot/framework.dev/contributors?anon=1',
+
+						{
+							headers: {
+								Authorization: `Token ${process.env.GITHUB_API_ACCESS_TOKEN}`,
+							},
+						}
+				  )
+				: await fetch(
+						'https://api.github.com/repos/thisdot/framework.dev/contributors?anon=1'
+				  )
+
 		if (!response.ok) {
 			throw abortError
 		}

--- a/packages/system/src/github-util/get-contributors.ts
+++ b/packages/system/src/github-util/get-contributors.ts
@@ -10,20 +10,19 @@ interface ContributorApiData {
 export const getContributorsData = async (): Promise<ContributorData[]> => {
 	const runFetch = async () => {
 		const abortError = new AbortError('Failed to fetch contributors')
-		const response =
-			process.env.NODE_ENV !== 'development'
-				? await fetch(
-						'https://api.github.com/repos/thisdot/framework.dev/contributors?anon=1',
+		const response = process.env.GITHUB_API_ACCESS_TOKEN
+			? await fetch(
+					'https://api.github.com/repos/thisdot/framework.dev/contributors?anon=1',
 
-						{
-							headers: {
-								Authorization: `Token ${process.env.GITHUB_API_ACCESS_TOKEN}`,
-							},
-						}
-				  )
-				: await fetch(
-						'https://api.github.com/repos/thisdot/framework.dev/contributors?anon=1'
-				  )
+					{
+						headers: {
+							Authorization: `Token ${process.env.GITHUB_API_ACCESS_TOKEN}`,
+						},
+					}
+			  )
+			: await fetch(
+					'https://api.github.com/repos/thisdot/framework.dev/contributors?anon=1'
+			  )
 
 		if (!response.ok) {
 			throw abortError


### PR DESCRIPTION
## Type of change


- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change

This resolved the issues of the failing contributor message in local development. Now we are only use the authorization header when in production. 

## Checklist


- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors


