### PR TITLE
fix: replacing broken vue images

### DIFF
--- a/packages/site/src/data/vue/libraries.ts
+++ b/packages/site/src/data/vue/libraries.ts
@@ -122,10 +122,10 @@ export const libraries: Library[] = [
 		author: 'quatrochan',
 		repo: 'https://www.github.com/quatrochan/Equal',
 		package: 'https://www.npmjs.com/package/equal-vue',
-		href: 'https://quatrochan.github.io/Equal/',
+		href: 'https://equal-ui.github.io/Equal/',
 		description:
 			'Equal UI is a Vue 3 components library with 30+ components based on TypeScript and personal design system.',
-		image: 'https://quatrochan.github.io/Equal/eqqqual.png',
+		image: 'https://equal-ui.github.io/Equal/logo.svg',
 		tags: [LibraryTag.COMPONENT],
 		language: 'TypeScript',
 	},
@@ -150,7 +150,7 @@ export const libraries: Library[] = [
 		description:
 			'PrimeVue is a rich set of open source UI Components for Vue. See PrimeVue homepage for live showcase and documentation.',
 		image:
-			'https://www.primefaces.org/primevue/demo/images/primevue-logo-dark.svg',
+			'https://primefaces.org/cdn/primevue/images/landing/overview-icon.svg',
 		tags: [LibraryTag.COMPONENT],
 		language: 'TypeScript',
 	},
@@ -246,7 +246,7 @@ export const libraries: Library[] = [
 		href: 'https://www.naiveui.com/',
 		description:
 			'A Vue 3 Component Library. Fairly Complete, Customizable Themes, Uses TypeScript, Not Too Slow. Kinda Interesting.',
-		image: 'https://www.naiveui.com/assets/naivelogo.93278402.svg',
+		image: 'https://www.naiveui.com/assets/naivelogo-93278402.svg',
 		tags: [LibraryTag.COMPONENT],
 		language: 'TypeScript',
 	},


### PR DESCRIPTION
## Type of change
closes #715 


- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change
I found a few broken images in the libraries section in the Vue site. I also found a broken link and fixed that too. 

- fixed broken link for Equal UI
- fixed broken image for Equal UI
- fixed broken image for PrimeVue
- fixed broken image for Naive Ui

## New images
<img width="490" alt="Screenshot 2023-02-20 at 11 57 43 AM" src="https://user-images.githubusercontent.com/67210629/220189227-39c6e754-2d95-4aa8-ac16-ed6cfac69821.png">

<img width="485" alt="Screenshot 2023-02-20 at 11 57 55 AM" src="https://user-images.githubusercontent.com/67210629/220189249-10b6e2e6-76d4-45c7-903c-49157f4ae399.png">


<img width="508" alt="Screenshot 2023-02-20 at 11 58 06 AM" src="https://user-images.githubusercontent.com/67210629/220189268-0ced1bfa-895a-45e6-b808-be99043aa10e.png">



## Checklist

- [x] This fix resolves #<!-- replace with issue number -->
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors
