### PR TITLE
feat: new communities heading

### DIFF
--- a/packages/system/src/components/homepage/communities.tsx
+++ b/packages/system/src/components/homepage/communities.tsx
@@ -19,7 +19,7 @@ export function Communities({
 	return (
 		<ContentBanner
 			className={classNames(className, communitiesStyle)}
-			title="Connect with the React Community"
+			title="Discover new communities"
 			viewAll={{
 				title: 'View all communities',
 				href: '/categories/communities',

--- a/packages/system/src/components/homepage/content-banner.tsx
+++ b/packages/system/src/components/homepage/content-banner.tsx
@@ -35,7 +35,7 @@ export function ContentBanner({
 	return (
 		<div className={classNames(className, contentBannerStyle)} {...props}>
 			<div className={contentBannerTextAreaStyle}>
-				<h2 className={contentBannerHeadingStyle}>Discover new communities</h2>
+				<h2 className={contentBannerHeadingStyle}>{title}</h2>
 				<a className={contentBannersViewAllStyle} href={viewAll.href}>
 					{viewAll.title}
 				</a>

--- a/packages/system/src/components/homepage/content-banner.tsx
+++ b/packages/system/src/components/homepage/content-banner.tsx
@@ -35,7 +35,7 @@ export function ContentBanner({
 	return (
 		<div className={classNames(className, contentBannerStyle)} {...props}>
 			<div className={contentBannerTextAreaStyle}>
-				<h2 className={contentBannerHeadingStyle}>Get smarter on the go</h2>
+				<h2 className={contentBannerHeadingStyle}>Discover new communities</h2>
 				<a className={contentBannersViewAllStyle} href={viewAll.href}>
 					{viewAll.title}
 				</a>


### PR DESCRIPTION
## Summary 

Updates communities section heading from "Get smarter on the go" to "Discover new communities"

Closes #714 

<img width="1179" alt="Screen Shot 2023-03-03 at 1 17 29 PM" src="https://user-images.githubusercontent.com/3721977/222797243-30f630b7-1c48-4a3d-a04f-eff28fd03cfc.png">

