### PR TITLE
fix: Improved Decoded Frontend Logo Image

### DIFF
--- a/packages/site/src/data/angular/courses.ts
+++ b/packages/site/src/data/angular/courses.ts
@@ -205,7 +205,7 @@ export const courses: Course<(typeof courseTags)[number]>[] = [
 		title: 'Decoded Frontend',
 		author: 'Dmytro Mezhenskyi',
 		image:
-			'https://yt3.ggpht.com/ytc/AKedOLTRAN09hQv5mKM-q_dPdOo57tg14n3qKnx-bQNu0Q=s88-c-k-c0x00ffffff-no-rj',
+			'https://yt3.googleusercontent.com/ytc/AL5GRJXYcSu1PodvdB-HYAtiaFVjig2HJbCiJXTS7TGZmg=s900-c-k-c0x00ffffff-no-rj',
 		description:
 			'Decoded Training is a series of video tutorials about Angular and generally about web development. New videos are published on a biweekly basis.',
 		paymentType: 'free',


### PR DESCRIPTION
Replace with a better resolution version of the image

Closes #713 


![Screen Shot 2023-03-02 at 3 59 20 PM](https://user-images.githubusercontent.com/3721977/222553273-57f6f234-9b65-48fa-aa22-1d1ad518ba73.png)
