### PR TITLE
fix: Change heading type for landing page resource cards

### DIFF
--- a/packages/system/src/components/landing/resources-info-banner.tsx
+++ b/packages/system/src/components/landing/resources-info-banner.tsx
@@ -27,7 +27,7 @@ export function ResourcesInfoBanner({
 }: ResourcesInfoBannerProps) {
 	return (
 		<div {...props} className={classNames(className, resourcesInfoBannerStyle)}>
-			<h4 className={resourcesInfoBannerHeadingStyle}>{title}</h4>
+			<h2 className={resourcesInfoBannerHeadingStyle}>{title}</h2>
 			<p className={resourcesInfoBannerDescriptionStyle}>{description}</p>
 			<LinkCardGroupComponent
 				className={resourcesInfoBannerCardsStyle}


### PR DESCRIPTION
## Summary

Update the ResourceInfoBanner heading to be an h2 tag. Checked around and it doesn't really effect anything else. Cleared up the noted issue from lighthouse report

Closes #710 