### PR TITLE
fix: Broken DevTernity Images

### DIFF
--- a/packages/site/src/data/angular/communities.ts
+++ b/packages/site/src/data/angular/communities.ts
@@ -121,7 +121,8 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'DevTernity',
 		description:
 			'Turning developers into architects and engineering leaders since 2015.',
-		image: 'https://devternity.com/images/favicon.png',
+		image:
+			'https://raw.githubusercontent.com/devternity/graphics/master/logos/devternity_2017_square_black_bg.png',
 		type: 'Live Events',
 		href: 'https://devternity.com/',
 		tags: ['conferences'],

--- a/packages/site/src/data/deno/communities.ts
+++ b/packages/site/src/data/deno/communities.ts
@@ -98,7 +98,8 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'DevTernity',
 		description:
 			'Turning developers into architects and engineering leaders since 2015.',
-		image: 'https://devternity.com/images/favicon.png',
+		image:
+			'https://raw.githubusercontent.com/devternity/graphics/master/logos/devternity_2017_square_black_bg.png',
 		type: 'Live Events',
 		href: 'https://devternity.com/',
 		tags: ['conferences'],

--- a/packages/site/src/data/react/communities.ts
+++ b/packages/site/src/data/react/communities.ts
@@ -140,7 +140,8 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'DevTernity',
 		description:
 			'Turning developers into architects and engineering leaders since 2015.',
-		image: 'https://devternity.com/images/favicon.png',
+		image:
+			'https://raw.githubusercontent.com/devternity/graphics/master/logos/devternity_2017_square_black_bg.png',
 		type: 'Live Events',
 		href: 'https://devternity.com/',
 		tags: ['conferences'],

--- a/packages/site/src/data/vue/communities.ts
+++ b/packages/site/src/data/vue/communities.ts
@@ -143,7 +143,8 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'DevTernity',
 		description:
 			'Turning developers into architects and engineering leaders since 2015.',
-		image: 'https://devternity.com/images/favicon.png',
+		image:
+			'https://raw.githubusercontent.com/devternity/graphics/master/logos/devternity_2017_square_black_bg.png',
 		type: 'Live Events',
 		href: 'https://devternity.com/',
 		tags: ['conferences'],


### PR DESCRIPTION
Updates with the url to the logos hosted on their GitHub repositories.

Closes #712 

![Screen Shot 2023-03-06 at 3 02 27 PM](https://user-images.githubusercontent.com/3721977/223218369-34a12355-9f5e-4fdd-824f-9f9f86b15ccf.png)
