### PR TITLE
fix(svelte): replace cut off svelte icons in tools

### DIFF
--- a/packages/site/src/data/svelte/tools.ts
+++ b/packages/site/src/data/svelte/tools.ts
@@ -16,7 +16,7 @@ export const tools: Tool<(typeof toolTags)[number]>[] = [
 		author: 'Svelte',
 		description: 'Interactive Svelte playground',
 		image:
-			'https://upload.wikimedia.org/wikipedia/commons/thumb/1/1b/Svelte_Logo.svg/498px-Svelte_Logo.svg.png?20191219133350',
+			'https://svelte.gallerycdn.vsassets.io/extensions/svelte/svelte-vscode/106.2.0/1665421195352/Microsoft.VisualStudio.Services.Icons.Default',
 		href: 'https://svelte.dev/repl/32f4d35f41eb4914aa3be5e4a0eacbfa?version=3.55.1',
 		tags: ['development'],
 	},
@@ -25,7 +25,7 @@ export const tools: Tool<(typeof toolTags)[number]>[] = [
 		author: 'JetBrains s.r.o.',
 		description: 'Support for Svelte in your JetBrains IDE of choice.',
 		image:
-			'https://plugins.jetbrains.com/files/12375/241423/icon/pluginIcon.svg',
+			'https://svelte.gallerycdn.vsassets.io/extensions/svelte/svelte-vscode/106.2.0/1665421195352/Microsoft.VisualStudio.Services.Icons.Default',
 		href: 'https://plugins.jetbrains.com/plugin/12375-svelte',
 		tags: ['Jetbrains'],
 	},


### PR DESCRIPTION
## Type of change
JetBrains IDE

Closes https://github.com/thisdot/framework.dev/issues/722

<!-- Add an x to the categories that apply -->

- [x] Bug fix

## Summary of change

Replaced image property for **Svetle REPL**and **Svelte for JetBrains IDEs** with the image from **Svelte for VS Code**

### Before
<img width="992" alt="Screenshot 2023-03-07 at 10 56 11 AM" src="https://user-images.githubusercontent.com/76821/223493412-5a023599-4853-4053-acdf-46b9db038634.png">



### After
<img width="993" alt="Screenshot 2023-03-07 at 10 55 34 AM" src="https://user-images.githubusercontent.com/76821/223493435-5b8ad521-61b8-46d8-a192-f7320f70833d.png">

## Checklist

<!-- Delete if your change is not a bug fix -->

- [x] This fix resolves #722
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors

