### PR TITLE
fix: GraphQL site logo images

### DIFF
--- a/packages/site/src/data/graphql/courses.ts
+++ b/packages/site/src/data/graphql/courses.ts
@@ -139,7 +139,7 @@ export const courses: Course<(typeof courseTags)[number]>[] = [
 		title: 'Server-Side GraphQL ',
 		author: 'Scott Moss',
 		image:
-			'https://pbs.twimg.com/profile_images/1563402109764022274/GYLY9j6g_400x400.jpg',
+			'https://static.frontendmasters.com/assets/courses/2019-11-25-server-graphql-nodejs/thumb.webp',
 		description:
 			'Learn everything you need to create a GraphQL API on the server in Node.js with Apollo Server.',
 		paymentType: 'paid',
@@ -152,7 +152,7 @@ export const courses: Course<(typeof courseTags)[number]>[] = [
 		title: 'Client-Side GraphQL ',
 		author: 'Scott Moss',
 		image:
-			'https://pbs.twimg.com/profile_images/1563402109764022274/GYLY9j6g_400x400.jpg',
+			'https://static.frontendmasters.com/assets/courses/2019-12-03-client-graphql-react/thumb.webp',
 		description:
 			'Learn to use GraphQL on the client-side using React with Apollo Client.',
 		paymentType: 'paid',
@@ -256,7 +256,7 @@ export const courses: Course<(typeof courseTags)[number]>[] = [
 		title: 'Advanced GraphQL ',
 		author: 'Scott Moss',
 		image:
-			'https://pbs.twimg.com/profile_images/1563402109764022274/GYLY9j6g_400x400.jpg',
+			'https://static.frontendmasters.com/assets/courses/2020-02-17-advanced-graphql-v2/thumb.webp',
 		description:
 			'Become a GraphQL master by learning to build production-ready GraphQL APIs in Node.js and Apollo Server.',
 		paymentType: 'paid',

--- a/packages/site/src/data/graphql/libraries.ts
+++ b/packages/site/src/data/graphql/libraries.ts
@@ -416,7 +416,7 @@ export const libraries: Library[] = [
 		href: 'https://wundergraph.com/',
 		description:
 			'WunderGraph is the Serverless API Developer Platform with a focus on Developer Experience.',
-		image: 'https://github.com/wundergraph.png',
+		image: 'https://hub.wundergraph.com/images/logo.svg',
 		language: 'NodeJS',
 		tags: [LibraryTag.DATA_PROCESSING],
 	},
@@ -453,7 +453,8 @@ export const libraries: Library[] = [
 		href: 'https://github.com/B2o5T/graphql-eslint',
 		description:
 			'This project integrates GraphQL and ESLint, for a better developer experience.',
-		image: 'https://github.com/B2o5T/graphql-eslint/raw/master/logo.png',
+		image:
+			'https://raw.githubusercontent.com/B2o5T/graphql-eslint/master/website/public/logo.png',
 		language: 'TypeScript',
 		tags: [LibraryTag.TOOLING, LibraryTag.CLI],
 	},

--- a/packages/site/src/data/graphql/tools.ts
+++ b/packages/site/src/data/graphql/tools.ts
@@ -84,8 +84,7 @@ export const tools: Tool<(typeof toolTags)[number]>[] = [
 		author: 'wp-graphql',
 		description:
 			'WPGraphQL allows you to separate your CMS from your presentation layer. Content creators can use the CMS they know, while developers can use the frameworks and tools they love.',
-		image:
-			'https://pbs.twimg.com/profile_images/1313701545452601345/cWC3a4Ux_400x400.jpg',
+		image: 'https://www.wpgraphql.com/logo-wpgraphql.svg',
 		href: 'https://www.wpgraphql.com/',
 		tags: ['schemas', 'frontend', 'backend', 'development'],
 	},
@@ -124,8 +123,7 @@ export const tools: Tool<(typeof toolTags)[number]>[] = [
 		author: 'WunderGraph',
 		description:
 			'Declaratively turn your services, databases and 3rd party APIs into a secure, unified, and extensible API. Compose, integrate, ship.',
-		image:
-			'https://pbs.twimg.com/profile_images/1588538504971272192/MGxcr3cH_400x400.jpg',
+		image: 'https://hub.wundergraph.com/images/logo.svg',
 		href: 'https://wundergraph.com/',
 		tags: ['schemas', 'frontend', 'backend', 'development'],
 	},
@@ -150,7 +148,8 @@ export const tools: Tool<(typeof toolTags)[number]>[] = [
 		author: 'AWS',
 		description:
 			'Accelerate application development with serverless GraphQL and Pub/Sub APIs',
-		image: 'https://appirio.com/images/partners/aws_logo-1.png',
+		image:
+			'https://seeklogo.com/images/A/aws-appsync-logo-1B6E8E9937-seeklogo.com.png',
 		href: 'https://aws.amazon.com/appsync/',
 		tags: ['schemas', 'frontend', 'backend', 'development'],
 	},


### PR DESCRIPTION
## Overview

Adds fixed logo images for missing or broken items on the GraphQL site
- wundergraph
- wp-graphql
- appsync
- graphql-eslint

Closes #719 