### PR TITLE
fix: JSConf Chile logos

### DIFF
--- a/packages/site/src/data/angular/communities.ts
+++ b/packages/site/src/data/angular/communities.ts
@@ -205,8 +205,7 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'JS Conf Chile',
 		description:
 			'2 days of international speakers, community, learning and connections.',
-		image:
-			'https://pbs.twimg.com/profile_images/1355572943552655362/QpnPItbv_400x400.jpg',
+		image: 'https://jsconf.com/images/jsconf_cl.png',
 		type: 'Live Events',
 		href: 'https://jsconf.cl/',
 		tags: ['conferences'],

--- a/packages/site/src/data/deno/communities.ts
+++ b/packages/site/src/data/deno/communities.ts
@@ -173,8 +173,7 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'JS Conf Chile',
 		description:
 			'2 days of international speakers, community, learning and connections.',
-		image:
-			'https://pbs.twimg.com/profile_images/1548041354806059008/CfEL7qut_400x400.jpg',
+		image: 'https://jsconf.com/images/jsconf_cl.png',
 		type: 'Live Events',
 		href: 'https://jsconf.cl/',
 		tags: ['conferences'],

--- a/packages/site/src/data/graphql/communities.ts
+++ b/packages/site/src/data/graphql/communities.ts
@@ -127,8 +127,7 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'JS Conf Chile',
 		description:
 			'2 days of international speakers, community, learning and connections.',
-		image:
-			'https://pbs.twimg.com/profile_images/1355572943552655362/QpnPItbv_400x400.jpg',
+		image: 'https://jsconf.com/images/jsconf_cl.png',
 		type: 'Live Events',
 		href: 'https://jsconf.cl/',
 		tags: ['conferences'],

--- a/packages/site/src/data/nodejs/communities.ts
+++ b/packages/site/src/data/nodejs/communities.ts
@@ -170,8 +170,7 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'JS Conf Chile',
 		description:
 			'2 days of international speakers, community, learning and connections.',
-		image:
-			'https://pbs.twimg.com/profile_images/1355572943552655362/QpnPItbv_400x400.jpg',
+		image: 'https://jsconf.com/images/jsconf_cl.png',
 		type: 'Live Events',
 		href: 'https://jsconf.cl/',
 		tags: ['conferences'],

--- a/packages/site/src/data/qwik/communities.ts
+++ b/packages/site/src/data/qwik/communities.ts
@@ -101,8 +101,7 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'JS Conf Chile',
 		description:
 			'2 days of international speakers, community, learning and connections.',
-		image:
-			'https://pbs.twimg.com/profile_images/1355572943552655362/QpnPItbv_400x400.jpg',
+		image: 'https://jsconf.com/images/jsconf_cl.png',
 		type: 'Live Events',
 		href: 'https://jsconf.cl/',
 		tags: ['conferences'],

--- a/packages/site/src/data/react/communities.ts
+++ b/packages/site/src/data/react/communities.ts
@@ -224,8 +224,7 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'JS Conf Chile',
 		description:
 			'2 days of international speakers, community, learning and connections.',
-		image:
-			'https://pbs.twimg.com/profile_images/1355572943552655362/QpnPItbv_400x400.jpg',
+		image: 'https://jsconf.com/images/jsconf_cl.png',
 		type: 'Live Events',
 		href: 'https://jsconf.cl/',
 		tags: ['conferences'],

--- a/packages/site/src/data/solidjs/communities.ts
+++ b/packages/site/src/data/solidjs/communities.ts
@@ -99,8 +99,7 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'Xtremejs',
 		description:
 			'Professional development conference dedicated to all things JavaScript.',
-		image:
-			'https://pbs.twimg.com/profile_images/1355572943552655362/QpnPItbv_400x400.jpg',
+		image: 'https://jsconf.com/images/jsconf_cl.png',
 		type: 'Online Events',
 		href: 'https://xtremejs.dev/',
 		tags: ['conferences'],

--- a/packages/site/src/data/svelte/communities.ts
+++ b/packages/site/src/data/svelte/communities.ts
@@ -110,8 +110,7 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'JS Conf Chile',
 		description:
 			'2 days of international speakers, community, learning and connections.',
-		image:
-			'https://pbs.twimg.com/profile_images/1355572943552655362/QpnPItbv_400x400.jpg',
+		image: 'https://jsconf.com/images/jsconf_cl.png',
 		type: 'Live Events',
 		href: 'https://jsconf.cl/',
 		tags: ['conferences'],

--- a/packages/site/src/data/vue/communities.ts
+++ b/packages/site/src/data/vue/communities.ts
@@ -227,8 +227,7 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'JS Conf Chile',
 		description:
 			'2 days of international speakers, community, learning and connections.',
-		image:
-			'https://pbs.twimg.com/profile_images/1355572943552655362/QpnPItbv_400x400.jpg',
+		image: 'https://jsconf.com/images/jsconf_cl.png',
 		type: 'Live Events',
 		href: 'https://jsconf.cl/',
 		tags: ['conferences'],


### PR DESCRIPTION
## Overview

Fixes broken JSConf chile logos across the site

Closes #725

![Screen Shot 2023-03-07 at 3 41 52 PM](https://user-images.githubusercontent.com/3721977/223547627-e98e2b71-8bff-44e9-b871-720a01f1dd04.png)
