### PR TITLE
fix(deno): replace blurry courses images

### DIFF
--- a/packages/site/src/data/deno/courses.ts
+++ b/packages/site/src/data/deno/courses.ts
@@ -67,7 +67,7 @@ export const courses: Course<(typeof courseTags)[number]>[] = [
 		paymentType: 'paid',
 		level: 'beginner',
 		format: 'video',
-		image: 'https://pluralsight.imgix.net/author/lg/brice-wilson-v2.jpg?w=200',
+		image: 'https://pluralsight.imgix.net/author/lg/brice-wilson-v2.jpg?w=353',
 		href: 'https://www.pluralsight.com/courses/deno-getting-started',
 		tags: [
 			'deno',
@@ -133,7 +133,7 @@ export const courses: Course<(typeof courseTags)[number]>[] = [
 		level: 'intermediate',
 		format: 'interactive',
 		image:
-			'https://images.ctfassets.net/aq13lwl6616q/719IZvU4LVWt9rECcR0oG3/a0da40259fde3f116d7e419d5536e86d/bdIvNmsR_400x400.jpg?w=30&fm=webp',
+			'https://images.ctfassets.net/aq13lwl6616q/719IZvU4LVWt9rECcR0oG3/a0da40259fde3f116d7e419d5536e86d/bdIvNmsR_400x400.jpg?w=353',
 		href: 'https://zerotomastery.io/courses/learn-deno/',
 		tags: ['deno', 'backend', 'debugging', 'typescript', 'aws', 'docker'],
 	},


### PR DESCRIPTION
## Type of change
Replace blurry images on nodejs courses page with higher quality

### Before
<img width="736" alt="Screenshot 2023-03-09 at 4 50 43 PM" src="https://user-images.githubusercontent.com/76821/224178328-ade670ab-0c08-4db2-84ec-a448f357fb7f.png">


### After
<img width="731" alt="Screenshot 2023-03-09 at 4 49 09 PM" src="https://user-images.githubusercontent.com/76821/224178316-235f1351-50dc-4f57-bcb4-c860c30acd55.png">


- [x] Bug fix

## Summary of change
Change the url for these images to request a size of width `353` instead of whatever they were before

## Checklist


<!-- Delete if your change is not a bug fix -->

- [x] This fix resolves #724  
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors
