### PR TITLE
feat: adding podcasts and libraries for svelte framework site

### DIFF
--- a/packages/site/src/data/svelte/libraries.ts
+++ b/packages/site/src/data/svelte/libraries.ts
@@ -209,4 +209,16 @@ export const libraries: Library[] = [
 			'A component that allows you to set head meta information, canonical, title, Twitter and Facebook Open Graph tags.',
 		language: 'TypeScript',
 	},
+	{
+		name: 'Axios',
+		author: 'Matt Zabriskie',
+		repo: 'https://github.com/axios/axios',
+		package: 'https://www.npmjs.com/package/axios',
+		href: 'https://axios-http.com/',
+		description:
+			'Axios is a promise-based HTTP Client for node.js and the browser. On the server-side it uses the native node.js http module, while on the client (browser) it uses XMLHttpRequests.',
+		image: defaultImage,
+		tags: [LibraryTag.FRAMEWORKS],
+		language: 'NodeJS',
+	},
 ]

--- a/packages/site/src/data/svelte/podcasts.ts
+++ b/packages/site/src/data/svelte/podcasts.ts
@@ -68,4 +68,34 @@ export const podcasts: Podcast<(typeof podcastTags)[number]>[] = [
 		href: 'https://builditbetter.podbean.com',
 		tags: ['general'],
 	},
+	{
+		title: 'JavaScript Air',
+		image:
+			'https://is4-ssl.mzstatic.com/image/thumb/Podcasts115/v4/68/98/c5/6898c591-1df3-dbdf-7173-72d66cc191ea/mza_12268657556293204019.png/626x0w.webp',
+		hosts: ['Kent C. Dodds'],
+		description: 'The live broadcast podcast all about JavaScript',
+		rss: 'https://feed.podbean.com/audio.javascriptair.com/feed.xml',
+		href: 'https://podcasts.apple.com/us/podcast/javascript-air/id1066446588',
+		tags: ['general'],
+	},
+	{
+		title: 'JS Party',
+		image:
+			'https://cdn.changelog.com/uploads/covers/js-party-original.png?v=63725770332',
+		hosts: [
+			'Jerod Santo',
+			'Feross Aboukhadijeh',
+			'Amelia Wattenberger',
+			'Kevin Ball',
+			'Nick Nisi',
+			'Divya',
+			'Mikeal Rogers',
+			'Christopher Hiller',
+			'Amal Hussein',
+		],
+		description: 'a weekly celebration of JavaScript and the web',
+		rss: 'https://jsparty.fm/rss',
+		href: 'https://changelog.com/topic/svelte/podcasts',
+		tags: ['general'],
+	},
 ]


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [x] Content addition
- [ ] Bug fix
- [ ] Behavior change

## Summary of change

We had this [PR](https://github.com/thisdot/framework.dev/pull/339/files) here which added some new podcasts and libraries to the svelte site. 
But since it was opened a while ago, there were some merge conflicts, the amplify links no longer worked, and some of the original content entries had already been added. 
So I opened a new PR. 


## Checklist

- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have searched all existing content and verified my additions are novel
      and unique
- [x] The content was added to the end of the appropriate data list
- [x] All required content fields are accurately populated
- [x] All items are tagged with all relevant tags



