### PR TITLE
Added solidjs router resource

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-	"typescript.tsdk": "node_modules/typescript/lib"
+	"typescript.tsdk": "node_modules/typescript/lib",
+	"nuxt.isNuxtApp": false
 }

--- a/packages/site/src/data/solidjs/libraries.ts
+++ b/packages/site/src/data/solidjs/libraries.ts
@@ -9,7 +9,7 @@ const defaultImage =
 export const libraries: Library[] = [
 	{
 		name: 'Solid Store',
-		author: 'SolidJs',
+		author: 'SolidJS',
 		repo: 'https://www.github.com/solidjs/solid/tree/main/packages/solid/store',
 		package: '',
 		href: 'https://www.solidjs.com/tutorial/stores_createstore',
@@ -59,7 +59,7 @@ export const libraries: Library[] = [
 	},
 	{
 		name: 'Solid Resources',
-		author: 'SolidJs',
+		author: 'SolidJS',
 		repo: 'https://github.com/solidjs/solid',
 		package: '',
 		href: 'https://www.solidjs.com/tutorial/async_resources',
@@ -135,7 +135,7 @@ export const libraries: Library[] = [
 		repo: 'https://www.github.com/DigiChanges/solid-multiselect',
 		package: 'https://www.npmjs.com/package/@digichanges/solid-multiselect',
 		href: 'https://github.com/DigiChanges/solid-multiselect',
-		description: 'A multi-select dropdown implementation for SolidJs',
+		description: 'A multi-select dropdown implementation for SolidJS',
 		image:
 			'https://opengraph.githubassets.com/3d77a1fbc9cc60af77bbd066466a010b7fd84422c2564802223a006317e81e7e/DigiChanges/solid-multiselect',
 		tags: [LibraryTag.COMPONENT],
@@ -160,7 +160,7 @@ export const libraries: Library[] = [
 		repo: 'https://www.github.com/swordev/suid',
 		package: 'https://www.npmjs.com/package/suid',
 		href: 'https://suid.io/',
-		description: 'A port of MUI built with SolidJs',
+		description: 'A port of MUI built with SolidJS',
 		image: 'https://suid.io/assets/preview.png',
 		tags: [LibraryTag.COMPONENT],
 		language: 'TypeScript',
@@ -180,7 +180,7 @@ export const libraries: Library[] = [
 	},
 	{
 		name: 'Solid Start',
-		author: 'SolidJs',
+		author: 'SolidJS',
 		repo: 'https://www.github.com/solidjs/solid-start',
 		package: '',
 		href: 'https://start.solidjs.com/getting-started/what-is-solidstart',
@@ -193,7 +193,7 @@ export const libraries: Library[] = [
 	},
 	{
 		name: 'Solid Form Handler',
-		author: 'SolidJs',
+		author: 'SolidJS',
 		repo: 'https://www.github.com/webblocksapp/solid-form-handler',
 		package: 'https://www.npmjs.com/package/solid-form-handler',
 		href: 'https://solid-form-handler.com/docs/introduction',
@@ -242,7 +242,7 @@ export const libraries: Library[] = [
 	},
 	{
 		name: 'Solid Router',
-		author: 'SolidJs',
+		author: 'SolidJS',
 		repo: 'https://github.com/solidjs/solid-router',
 		package: '',
 		description:

--- a/packages/site/src/data/solidjs/libraries.ts
+++ b/packages/site/src/data/solidjs/libraries.ts
@@ -59,7 +59,7 @@ export const libraries: Library[] = [
 	},
 	{
 		name: 'Solid Resources',
-		author: 'Solidjs',
+		author: 'SolidJs',
 		repo: 'https://github.com/solidjs/solid',
 		package: '',
 		href: 'https://www.solidjs.com/tutorial/async_resources',
@@ -180,7 +180,7 @@ export const libraries: Library[] = [
 	},
 	{
 		name: 'Solid Start',
-		author: 'solidjs',
+		author: 'SolidJs',
 		repo: 'https://www.github.com/solidjs/solid-start',
 		package: '',
 		href: 'https://start.solidjs.com/getting-started/what-is-solidstart',
@@ -193,7 +193,7 @@ export const libraries: Library[] = [
 	},
 	{
 		name: 'Solid Form Handler',
-		author: 'solidjs',
+		author: 'SolidJs',
 		repo: 'https://www.github.com/webblocksapp/solid-form-handler',
 		package: 'https://www.npmjs.com/package/solid-form-handler',
 		href: 'https://solid-form-handler.com/docs/introduction',
@@ -238,6 +238,19 @@ export const libraries: Library[] = [
 		image: 'https://vitejs.dev/logo.svg',
 		href: 'https://github.com/vitejs/vite',
 		tags: [LibraryTag.TOOLING],
+		language: 'TypeScript',
+	},
+	{
+		name: 'Solid Router',
+		author: 'SolidJs',
+		repo: 'https://github.com/solidjs/solid-router',
+		package: '',
+		description:
+			'A universal router for Solid inspired by Ember and React Router',
+		image:
+			'https://opengraph.githubassets.com/41111dcd4fc2ba4f3f3c097212fa56ffc1e2e6abde27785dba293e8341132d49/solidjs/solid-router',
+		href: 'https://github.com/solidjs/solid-router',
+		tags: [LibraryTag.ROUTING],
 		language: 'TypeScript',
 	},
 	{


### PR DESCRIPTION
# Description

- Items are able to have multiple tags, and Solid Router should show under the Routing tag on framework.dev

# Acceptance Criteria

- [x] Solid Router is displayed under Router 


![Image](https://user-images.githubusercontent.com/1828602/227525895-597195d7-54ac-441d-90ab-cf3d01394c29.png)



![Screenshot 2023-03-24 at 15 39 59](https://user-images.githubusercontent.com/28502531/227557361-d9a3bb8c-d0f1-4fd0-98c4-82099cce167f.jpg)
