### PR TITLE
chore: adding slack notifications GH action

### DIFF
--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -1,0 +1,49 @@
+name: 'Send Slack notification when PR is merged'
+on:
+  pull_request:
+    types:
+      - closed
+jobs:
+  send-slack-notification:
+    if:
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack message
+        id: slack
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Another PR was just merged into framework.dev :tada:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*${{ github.event.pull_request.user.login }}* has just contributed to framework.dev :partying_face:"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*${{ github.event.pull_request.user.login }}* made the following changes:  <${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Content addition
- [ ] Bug fix
- [x] Behavior change

## Summary of change

This PR is responsible for adding a slack notification when a PR is merged. I tested this with my personal slack setup. 
closes #768 

<img width="735" alt="testing-slack-notifications" src="https://github.com/thisdot/framework.dev/assets/67210629/a2807728-4871-45ce-9f23-852fdc23e4c9">


## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

<!-- Delete if your change is not a content addition -->

- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)





