### PR TITLE
fix: vue-the-road-to-enterprise cover image broken

### DIFF
--- a/packages/site/src/data/vue/books.ts
+++ b/packages/site/src/data/vue/books.ts
@@ -33,7 +33,7 @@ export const books: Book<(typeof bookTags)[number]>[] = [
 	{
 		title: 'Vue The Road To Enterprise',
 		authors: ['Thomas Findlay'],
-		image: 'https://theroadtoenterprise.com/_nuxt/img/fdc3f54.png',
+		image: 'https://theroadtoenterprise.com/images/vue-book-cover-3d.png',
 		description:
 			'Take your skills to the next level and become a Vue pro by mastering advanced patterns, best practices, and cutting-edge techniques for the development of Vue 2 & 3 applications.',
 		yearOfPublication: 2021,


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change

<!-- Provide a brief summary of what changes this PR includes, like "added some popular React podcasts" or "fixed navigation menu getting cut off on screens narrower than 320px" -->
![image](https://github.com/thisdot/framework.dev/assets/90845831/cc18a6e4-2ad1-48de-83f6-e37a1b72d7d1)


## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

<!-- Delete if your change is not a content addition -->

- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [ ] I have searched all existing content and verified my additions are novel
      and unique
- [ ] The content was added to the end of the appropriate data list
- [ ] All required content fields are accurately populated
- [ ] All items are tagged with all relevant tags

