### PR TITLE
fix: broken angular images

### DIFF
--- a/packages/site/src/data/angular/communities.ts
+++ b/packages/site/src/data/angular/communities.ts
@@ -149,7 +149,7 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'International Javascript Conference',
 		description: 'Conference dedicated to full stack JavaScript development',
 		image:
-			'https://pbs.twimg.com/profile_images/841217931455401984/uzU4VfwA_400x400.jpg',
+			'https://pbs.twimg.com/profile_images/1650499473653608452/8PA1Tnvl_400x400.jpg',
 		type: 'Live Events',
 		href: 'https://javascript-conference.com/',
 		tags: ['conferences'],
@@ -264,7 +264,7 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		description:
 			'CSS Day Conf features a mix of CSS designers, developers, spec writers and browser vendors, who take pride in what they know and do.',
 		image:
-			'https://pbs.twimg.com/profile_images/3086361545/375adf0a29fbd0e21eb6315f3fd681c6_400x400.png',
+			'https://pbs.twimg.com/profile_images/1643163121668718594/s3pkjWE6_400x400.jpg',
 		type: 'Live Events',
 		href: 'https://cssday.nl/2022',
 		tags: ['conferences'],
@@ -300,9 +300,10 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'Angular Nation',
 		description:
 			'A free and friendly place to network and collaborate with Angular developers just  like you!',
-		image: 'https://pbs.twimg.com/profile_images/1331571398834315264/xtrGFRx-_400x400.jpg',
+		image:
+			'https://pbs.twimg.com/profile_images/1331571398834315264/xtrGFRx-_400x400.jpg',
 		type: 'Online Events',
 		href: 'https://www.angularnation.net/',
 		tags: ['meetups'],
-	}
+	},
 ]

--- a/packages/site/src/data/angular/libraries.ts
+++ b/packages/site/src/data/angular/libraries.ts
@@ -302,7 +302,7 @@ export const libraries: Library[] = [
 		description:
 			'Over 80 Angular UI Components with top-notch quality to help you implement all your UI requirements in style.',
 		image:
-			'https://www.primefaces.org/primeng/assets/showcase/images/primeng-logo-dark.svg',
+			'https://pbs.twimg.com/profile_images/1345334019131666432/7d8KUAdI_400x400.jpg',
 		tags: [LibraryTag.COMPONENT],
 		language: 'TypeScript',
 	},
@@ -637,7 +637,8 @@ export const libraries: Library[] = [
 		package: 'https://www.npmjs.com/package/@analogjs/platform',
 		href: 'https://analogjs.org/',
 		image: 'https://analogjs.org/img/favicon.ico',
-		description: 'Analog is a meta-framework for building applications and websites with Angular.',
+		description:
+			'Analog is a meta-framework for building applications and websites with Angular.',
 		tags: [LibraryTag.FRAMEWORKS],
 		language: 'TypeScript',
 	},
@@ -648,7 +649,8 @@ export const libraries: Library[] = [
 		package: 'https://www.npmjs.com/package/taiga-ui',
 		href: 'https://taiga-ui.dev/',
 		image: 'https://taiga-ui.dev/assets/favicon-32x32.png',
-		description: 'Taiga UI is fully-treeshakable Angular UI Kit that contains 130+ components, 100+ directives, dozens of tokens, utils and tools.',
+		description:
+			'Taiga UI is fully-treeshakable Angular UI Kit that contains 130+ components, 100+ directives, dozens of tokens, utils and tools.',
 		tags: [LibraryTag.COMPONENT],
 		language: 'TypeScript',
 	},
@@ -659,7 +661,8 @@ export const libraries: Library[] = [
 		package: 'https://www.npmjs.com/package/@nebular/theme',
 		href: 'https://akveo.github.io/nebular/',
 		image: 'https://akveo.github.io/nebular/favicon.png',
-		description: 'Nebular is a customizable Angular UI library that contains 40+ UI components, four visual themes, and Auth and Security modules.',
+		description:
+			'Nebular is a customizable Angular UI library that contains 40+ UI components, four visual themes, and Auth and Security modules.',
 		tags: [LibraryTag.COMPONENT],
 		language: 'TypeScript',
 	},

--- a/packages/site/src/data/angular/podcasts.ts
+++ b/packages/site/src/data/angular/podcasts.ts
@@ -4,16 +4,6 @@ export const podcastTags = ['general'] as const
 
 export const podcasts: Podcast<(typeof podcastTags)[number]>[] = [
 	{
-		title: 'Angular Experience',
-		image: 'https://ngxp.show/assets/images/ngxpSiteImage2%20(1).png',
-		hosts: ['Brooke Avery', 'Erik Slack'],
-		description:
-			'NgXP a weekly podcast produced by Brooke Avery and Erik Slack, two programmers and event planners who are passionate about all things Angular and programming.',
-		rss: '',
-		href: 'https://ngxp.show/home',
-		tags: ['general'],
-	},
-	{
 		title: 'Angular Air',
 		image: 'https://angularair.com/assets/angularairlogo.png',
 		hosts: ['Justin Schwartzenberger'],


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change

This PR fixes the following:

- [x] fixes the broken image for CSS day
- [x] Fixes broken image for International JS conference
- [x] fixes broken image for PrimeNG
- [x] removes Angular Experience podcast since the link and image were no longer working
