### PR TITLE
fix: Broken link, wrong image for graphql course

### DIFF
--- a/packages/site/src/data/graphql/courses.ts
+++ b/packages/site/src/data/graphql/courses.ts
@@ -294,13 +294,13 @@ export const courses: Course<(typeof courseTags)[number]>[] = [
 	{
 		title: 'Intro to GraphQL DataLoaders',
 		author: 'Star Richardson',
-		image: 'https://avatars.githubusercontent.com/u/67430892?v=4',
+		image: 'https://pbs.twimg.com/profile_images/1249804296469778433/uRRNm6-n_400x400.png',
 		description:
 			"How to implement DataLoaders in your GraphQL project. We'll walk through setup and configuration, and build a simple API to demonstrate how GraphQL DataLoaders can dramatically reduce duplicate API calls.",
 		paymentType: 'free',
 		level: 'intermediate',
 		format: 'video',
-		href: 'www.youtube.com/watch?v=Zc6xv5bcky8',
+		href: 'https://www.youtube.com/watch?v=Zc6xv5bcky8',
 		tags: ['data fetching', 'graphQL', 'javascript marathon', 'services'],
 	},
 ]


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Content addition
- [x] Bug fix
- [ ] Behavior change

## Summary of change

With respect to the GraphQL DataLoader JS marathon course:

- [x] The logo should be This Dot and not Star's profile image

- [x] Clicking on the card does not go to YouTube

## Checklist


<!-- Delete if your change is not a bug fix -->

- [x] This fix resolves #700 
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors

