### PR TITLE
Hide books section on home page since books are empty

### DIFF
--- a/packages/site/src/data/angular/communities.ts
+++ b/packages/site/src/data/angular/communities.ts
@@ -149,7 +149,7 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'International Javascript Conference',
 		description: 'Conference dedicated to full stack JavaScript development',
 		image:
-			'https://pbs.twimg.com/profile_images/841217931455401984/uzU4VfwA_400x400.jpg',
+			'https://javascript-conference.com/wp-content/uploads/2019/12/Konferenzlogos_Website_Navi_68979_v1_iJS.png',
 		type: 'Live Events',
 		href: 'https://javascript-conference.com/',
 		tags: ['conferences'],
@@ -300,9 +300,10 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'Angular Nation',
 		description:
 			'A free and friendly place to network and collaborate with Angular developers just  like you!',
-		image: 'https://pbs.twimg.com/profile_images/1331571398834315264/xtrGFRx-_400x400.jpg',
+		image:
+			'https://pbs.twimg.com/profile_images/1331571398834315264/xtrGFRx-_400x400.jpg',
 		type: 'Online Events',
 		href: 'https://www.angularnation.net/',
 		tags: ['meetups'],
-	}
+	},
 ]

--- a/packages/site/src/data/deno/communities.ts
+++ b/packages/site/src/data/deno/communities.ts
@@ -126,7 +126,7 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'International Javascript Conference',
 		description: 'Conference dedicated to full stack JavaScript development',
 		image:
-			'https://pbs.twimg.com/profile_images/841217931455401984/uzU4VfwA_400x400.jpg',
+			'https://javascript-conference.com/wp-content/uploads/2019/12/Konferenzlogos_Website_Navi_68979_v1_iJS.png',
 		type: 'Live Events',
 		href: 'https://javascript-conference.com/',
 		tags: ['conferences'],

--- a/packages/site/src/data/graphql/communities.ts
+++ b/packages/site/src/data/graphql/communities.ts
@@ -71,7 +71,7 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'International Javascript Conference',
 		description: 'Conference dedicated to full stack JavaScript development',
 		image:
-			'https://pbs.twimg.com/profile_images/841217931455401984/uzU4VfwA_400x400.jpg',
+			'https://javascript-conference.com/wp-content/uploads/2019/12/Konferenzlogos_Website_Navi_68979_v1_iJS.png',
 		type: 'Live Events',
 		href: 'https://javascript-conference.com/',
 		tags: ['conferences'],

--- a/packages/site/src/data/nodejs/communities.ts
+++ b/packages/site/src/data/nodejs/communities.ts
@@ -123,7 +123,7 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'International Javascript Conference',
 		description: 'Conference dedicated to full stack JavaScript development',
 		image:
-			'https://pbs.twimg.com/profile_images/841217931455401984/uzU4VfwA_400x400.jpg',
+			'https://javascript-conference.com/wp-content/uploads/2019/12/Konferenzlogos_Website_Navi_68979_v1_iJS.png',
 		type: 'Live Events',
 		href: 'https://javascript-conference.com/',
 		tags: ['conferences'],

--- a/packages/site/src/data/qwik/communities.ts
+++ b/packages/site/src/data/qwik/communities.ts
@@ -45,7 +45,7 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'International Javascript Conference',
 		description: 'Conference dedicated to full stack JavaScript development',
 		image:
-			'https://pbs.twimg.com/profile_images/841217931455401984/uzU4VfwA_400x400.jpg',
+			'https://javascript-conference.com/wp-content/uploads/2019/12/Konferenzlogos_Website_Navi_68979_v1_iJS.png',
 		type: 'Live Events',
 		href: 'https://javascript-conference.com/',
 		tags: ['conferences'],

--- a/packages/site/src/data/react/communities.ts
+++ b/packages/site/src/data/react/communities.ts
@@ -168,7 +168,7 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'International Javascript Conference',
 		description: 'Conference dedicated to full stack JavaScript development',
 		image:
-			'https://pbs.twimg.com/profile_images/841217931455401984/uzU4VfwA_400x400.jpg',
+			'https://javascript-conference.com/wp-content/uploads/2019/12/Konferenzlogos_Website_Navi_68979_v1_iJS.png',
 		type: 'Live Events',
 		href: 'https://javascript-conference.com/',
 		tags: ['conferences'],

--- a/packages/site/src/data/solidjs/communities.ts
+++ b/packages/site/src/data/solidjs/communities.ts
@@ -136,7 +136,7 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'International Javascript Conference',
 		description: 'Conference dedicated to full stack JavaScript development',
 		image:
-			'https://pbs.twimg.com/profile_images/841217931455401984/uzU4VfwA_400x400.jpg',
+			'https://javascript-conference.com/wp-content/uploads/2019/12/Konferenzlogos_Website_Navi_68979_v1_iJS.png',
 		type: 'Live Events',
 		href: 'https://javascript-conference.com/',
 		tags: ['conferences'],

--- a/packages/site/src/data/solidjs/libraries.ts
+++ b/packages/site/src/data/solidjs/libraries.ts
@@ -76,9 +76,8 @@ export const libraries: Library[] = [
 		package: 'https://www.npmjs.com/package/@tanstack/solid-query',
 		href: 'https://tanstack.com/query/v4/docs/adapters/solid-query',
 		description:
-			'🤖 Powerful asynchronous state management, server-state utilities and data fetching for TS/JS, React, Solid, Svelte and Vue. - query/packages at main · TanStack/query',
-		image:
-			'https://raw.githubusercontent.com/TanStack/query/beta/media/repo-header.png',
+			'Powerful asynchronous state management, server-state utilities and data fetching for TS/JS, React, Solid, Svelte and Vue. - query/packages at main · TanStack/query',
+		image: 'https://avatars.githubusercontent.com/u/72518640?s=200&v=4',
 		tags: [LibraryTag.DATA_FETCHING],
 		language: 'TypeScript',
 	},

--- a/packages/site/src/data/svelte/blogs.ts
+++ b/packages/site/src/data/svelte/blogs.ts
@@ -17,7 +17,7 @@ export const blogs: Blog<(typeof blogTags)[number]>[] = [
 		title: 'Joy of Code',
 		author: 'Matija',
 		description:
-			"Matija from 🇭🇷 Croatia and he's infinitely curious at how things work but he's mostly passionate about ☕ JavaScript and 🎨 UI/UX design.",
+			"Matija from Croatia and he's infinitely curious at how things work but he's mostly passionate about JavaScript and UI/UX design.",
 		image:
 			'https://yt3.ggpht.com/f-nkXHIt4t8B7yFIOdkQBGEyTY0LVrS8DWkAnF6W7KazXPtcD2XHzWPSsOx_vAjVgs3RQu736cY=s176-c-k-c0x00ffffff-no-rj-mo',
 		href: 'https://joyofcode.xyz/categories/svelte',
@@ -83,16 +83,6 @@ export const blogs: Blog<(typeof blogTags)[number]>[] = [
 		image:
 			'https://magrippis.com/_next/image?url=%2Fimages%2Fhero.jpg&w=256&q=75',
 		href: 'https://magrippis.com/blog',
-		tags: [],
-	},
-	{
-		title: 'Rodney Lab',
-		author: 'Rodney',
-		description:
-			'Hello and welcome! I’m Rodney, a web developer based in the UK 🇬🇧 and am available for consultancy work.',
-		image:
-			'https://rodneylab.com/assets/rodney-johnson-about-rodneylab-1350x1350.208d1490.avif',
-		href: 'https://rodneylab.com/tags/sveltekit/',
 		tags: [],
 	},
 	{

--- a/packages/site/src/data/svelte/communities.ts
+++ b/packages/site/src/data/svelte/communities.ts
@@ -35,7 +35,7 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'Svelte Summit',
 		description:
 			'Svelte Summit is an event dedicated to Svelte and everything that is happening in the community.',
-		image: 'https://www.sveltesummit.com/_app/assets/logo-3e24e7c2.svg',
+		image: 'https://sveltesociety.dev/images/logo.svg',
 		type: 'Live Events',
 		href: 'https://www.sveltesummit.com/',
 		tags: [],
@@ -54,7 +54,7 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'International Javascript Conference',
 		description: 'Conference dedicated to full stack JavaScript development',
 		image:
-			'https://pbs.twimg.com/profile_images/841217931455401984/uzU4VfwA_400x400.jpg',
+			'https://javascript-conference.com/wp-content/uploads/2019/12/Konferenzlogos_Website_Navi_68979_v1_iJS.png',
 		type: 'Live Events',
 		href: 'https://javascript-conference.com/',
 		tags: ['conferences'],
@@ -199,14 +199,6 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		image: 'https://www.jsday.ie//media/jslogo.png?imwidth=64',
 		type: 'Live Events',
 		href: 'https://www.jsday.ie/',
-		tags: ['conferences'],
-	},
-	{
-		name: 'Svelte Summit',
-		description: 'A meetup dedicated to the latest release of Svelte',
-		image: 'https://sveltesociety.dev/images/logo.svg',
-		type: 'Live Events',
-		href: 'https://beta.guild.host/svelte-society-london/events',
 		tags: ['conferences'],
 	},
 	{

--- a/packages/site/src/data/vue/communities.ts
+++ b/packages/site/src/data/vue/communities.ts
@@ -171,7 +171,7 @@ export const communities: Community<(typeof communityTags)[number]>[] = [
 		name: 'International Javascript Conference',
 		description: 'Conference dedicated to full stack JavaScript development',
 		image:
-			'https://pbs.twimg.com/profile_images/841217931455401984/uzU4VfwA_400x400.jpg',
+			'https://javascript-conference.com/wp-content/uploads/2019/12/Konferenzlogos_Website_Navi_68979_v1_iJS.png',
 		type: 'Live Events',
 		href: 'https://javascript-conference.com/',
 		tags: ['conferences'],

--- a/packages/system/src/components/homepage/homepage.tsx
+++ b/packages/system/src/components/homepage/homepage.tsx
@@ -103,9 +103,15 @@ export function Homepage({
 					<Blogs blogs={blogs} />
 				</div>
 				<ContributorBanner contributors={contributorsData}></ContributorBanner>
-				<div className={homepageTwoAndOneSectionStyle}>
+				<div
+					className={
+						books.length !== 0
+							? homepageTwoAndOneSectionStyle
+							: ''
+					}
+				>
 					<LatestTools tools={tools} />
-					<Books books={books} />
+					{books.length !== 0 && <Books books={books} />}
 				</div>
 				<Communities communities={communities} />
 

--- a/packages/system/src/components/homepage/homepage.tsx
+++ b/packages/system/src/components/homepage/homepage.tsx
@@ -103,16 +103,14 @@ export function Homepage({
 					<Blogs blogs={blogs} />
 				</div>
 				<ContributorBanner contributors={contributorsData}></ContributorBanner>
-				<div
-					className={
-						books.length !== 0
-							? homepageTwoAndOneSectionStyle
-							: ''
-					}
-				>
+				{books.length > 0 ? (
+					<div className="homepageTwoAndOneSectionStyle">
+						<LatestTools tools={tools} />
+						<Books books={books} />
+					</div>
+				) : (
 					<LatestTools tools={tools} />
-					{books.length !== 0 && <Books books={books} />}
-				</div>
+				)}
 				<Communities communities={communities} />
 
 				<ResourcesInfoBanner


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Content addition
- [ ] Bug fix
- [x] Behavior change

## Summary of change

Hide books section on home page since books are empty

- Books has a big featured section on the homepage but SolidJS doesn't have any. We should probably consider a change to not make books so heavily featured and switch some homepage items around. Not a blocker but noting here.

<img width="1426" alt="Screenshot 2023-10-18 at 10 47 53" src="https://github.com/thisdot/framework.dev/assets/41862157/53022f76-731e-4328-91c4-23fdf01ecfc7">


## Checklist

- [ ] This change resolves #693 
- [x] I have confirmed with a maintainer that this change is desired and been
      given the go-ahead to work on it in the relevant issue discussion
- [x] The changes follow the [contributing guidelines](https://github.com/thisdot/framework.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the change and the rest of the site works as expected
- [ ] If the change introduces new components, these have been added to
      `packages/system/src/components` with a `.stories.tsx` file that
      adequately renders possible variations of each component.
